### PR TITLE
更正部分错误的条目解释

### DIFF
--- a/language/answer_zh.md
+++ b/language/answer_zh.md
@@ -177,7 +177,7 @@
 > 此检测项不稳定偶尔出现（通常使用KSU LKM模式的较多）
 
 ## Abnormal Environment
-> 检测到KSU/APatch
+> 检测到KSU/APatch（侧信道检测）
 > 
 KernelSU检测原理：
 KernelSU框架会使用Kprobe来hook newfsatat和faccessat系统调用接口，这使得调用两者所花费时间显著变长，但statx不受影响，而且在正常情况下，newfsatat和statx所花时间非常接近。
@@ -191,9 +191,12 @@ APatch检测原理：
 APatch管理器在向kernelpatch框架发起鉴权请求时，kernelpatch会读取APatch管理器所提供的superkey的所在地址（从before函数的udata参数传入）；kernelpatch在鉴权前会验证cmd值是否在范围内，在此范围内则允许鉴权，反之不允许。
 
 检测方法：
-1.“懒分配”页探测
-检测器先向系统申请一个“懒分配”页，将此“懒分配”页的所在地址当作superkey所在地址向kernelpatch发起鉴权请求，kernelpatch会访问此地址，尝试从中读取所谓的“superkey”，但实际上“懒分配”页中不存在superkey，而由于kernelpatch尝试读取该页，系统会自动将“懒分配”页映射到一个物理内存块，此时检测器检查此页是否被映射到物理内存块，如果被映射即可判定存在kernelpatch，反之说明kernelpatch不存在。
+1. “懒分配”页探测
+
+检测器先向系统申请一个“懒分配”页，将此“懒分配”页的所在地址当作superkey所在地址向kernelpatch发起鉴权请求，kernelpatch会解引用此地址，尝试从中读取所谓的“superkey”，但实际上“懒分配”页中不存在于superkey，而由于kernelpatch尝试读取该页，系统会自动将“懒分配”页映射到一个物理内存块，此时检测器检查此页是否被映射到物理内存块，如果被映射即可判定存在kernelpatch，反之说明kernelpatch不存在。
+
 2. 鉴权时延探测
+
 kernelpatch在尝试读取superkey之前有一个检查cmd值的步骤，如果cmd值在范围内（SUPERCALL_HELLO和SUPERCALL_MAX之间）将会走向读取和验证superkey，反之会快速返回结束鉴权，这两种走向的花费时间是不同的，检测器可以提前拟定一个在范围内的cmd值和不在范围内的cmd值，分别向kernelpatch发起鉴权请求，同样的，多次测量范围内cmd和范围外cmd所花费的时间，取其总和来让比值趋于稳定，如果比值大于2，则判定kernelpatch存在。
 
 懒分配：当用户态程序向操作系统请求分配页时，操作系统为了节省物理内存空间，会在虚拟内存分配该页，但不映射物理内存块，直到此页被真正访问后才会实质上分配内存块。

--- a/language/answer_zh.md
+++ b/language/answer_zh.md
@@ -179,7 +179,29 @@
 ## Abnormal Environment
 > 检测到KSU/APatch
 > 
-> 测信道检测,更新你的根管理器并重新修补
+KernelSU检测原理：
+KernelSU框架会使用Kprobe来hook newfsatat和faccessat系统调用接口，这使得调用两者所花费时间显著变长，但statx不受影响，而且在正常情况下，newfsatat和statx所花时间非常接近。
+检测方法：多次测量调用newfsatat和statx所花费的时间，取其总和来让比值趋于稳定，两者所花总时间的比值大于1.2时则判定存在KernelSU。
+
+> 解决办法：更新你的KenrelSU管理器并重新修补（LKM工作模式）或重新集成（GKI和Non-GKI工作模式）
+
+APatch检测原理：
+建议参照[此代码](https://github.com/bmax121/KernelPatch/blob/352de3747693d403eb1a4bd2c98dc04aeb01955a/kernel/patch/common/supercall.c)阅读
+
+APatch管理器在向kernelpatch框架发起鉴权请求时，kernelpatch会读取APatch管理器所提供的superkey的所在地址（从before函数的udata参数传入）；kernelpatch在鉴权前会验证cmd值是否在范围内，在此范围内则允许鉴权，反之不允许。
+
+检测方法：
+1.“懒分配”页探测
+检测器先向系统申请一个“懒分配”页，将此“懒分配”页的所在地址当作superkey所在地址向kernelpatch发起鉴权请求，kernelpatch会访问此地址，尝试从中读取所谓的“superkey”，但实际上“懒分配”页中不存在superkey，而由于kernelpatch尝试读取该页，系统会自动将“懒分配”页映射到一个物理内存块，此时检测器检查此页是否被映射到物理内存块，如果被映射即可判定存在kernelpatch，反之说明kernelpatch不存在。
+2. 鉴权时延探测
+kernelpatch在尝试读取superkey之前有一个检查cmd值的步骤，如果cmd值在范围内（SUPERCALL_HELLO和SUPERCALL_MAX之间）将会走向读取和验证superkey，反之会快速返回结束鉴权，这两种走向的花费时间是不同的，检测器可以提前拟定一个在范围内的cmd值和不在范围内的cmd值，分别向kernelpatch发起鉴权请求，同样的，多次测量范围内cmd和范围外cmd所花费的时间，取其总和来让比值趋于稳定，如果比值大于2，则判定kernelpatch存在。
+
+懒分配：当用户态程序向操作系统请求分配页时，操作系统为了节省物理内存空间，会在虚拟内存分配该页，但不映射物理内存块，直到此页被真正访问后才会实质上分配内存块。
+
+> 解决办法：
+> 1. 安装nohello kpm，并将检测器加入到排除列表，nohello可以在kernelpatach判断cmd值之前判断发起鉴权请求的应用是否在排除列表内，如果是，则禁止鉴权。
+> 2. 未来版本的APatch会引入基于签名的鉴权方法，对于不符合签名却发起了鉴权的应用直接拒绝鉴权请求。目前没有完全实现，需要再等一段时间。
+
 
 ## Abnormal Environment(04)
 > 新版更改为函数调用检测（不稳定？）
@@ -295,6 +317,7 @@ data 隔离？
 > 
 > 解决办法：
 > Magisk系：使用Magisk Alpha可解决，原理未知。
+> 
 > Kernel系/APatch系：尝试更换"元模块"解决或者更新ROOT管理器
 
 在少数ROM中原生存在此现象，如果属于这种情况 请忽略此条目

--- a/language/answer_zh.md
+++ b/language/answer_zh.md
@@ -7,7 +7,8 @@
 请开Issues并提供 你的模块列表信息+使用了哪些xp模块等详细修改 我有时间会回复/帮助。
 
 # Miscellaneous Check(12)
-> 尝试更新最新版LSPosed-it解决，或卸载模块，或者线刷双清
+> 通过扫描smaps启发式探测Zygisk实现（特别是Zygisk-Next），但目前的实现方式存在问题，导致检测失效。
+> 在检测方法被修复或移除前请忽略此条目
 
 # Looper fd图异常
 > 正在分析复现，待补充...
@@ -15,7 +16,7 @@
 # HMA或许存在
 > 疑似检测旧版使用Scene_Hide-eBPF模块行为（检测不到scene应用程序存在，但检测到相关服务）
 > 
-> [分支项目/拉取更新重新构建模块并刷入](https://github.com/Andrea-lyz/Scene-Port-Hider-by-eBPF)
+> [分支项目/拉取更新重新构建模块并刷入/从Relases中下载](https://github.com/Andrea-lyz/Scene-Port-Hider-by-eBPF)
 
 # 存在模块修改春秋
 > 使用IsolPolicy模块后出现，关闭作用域或者卸载模块解决
@@ -23,10 +24,11 @@
 > 并不是只有模块，比如说类似于面具的隐藏也算（比如SELinux修改隐藏）请尝试跟进相关root管理器最新CI来解决此问题
 
 # 检测SELinux Policy时发现可疑问题 / 检测到ROOT权限
+> 检测方式参考 https://github.com/LSPosed/DirtySepolicy
 > 新加入的SELinux特性检测（应用程序 zygote 拥有访问 /sys/fs/selinux/access 的权限）
 > KSU使用者[更新KSU管理器](https://t.me/KernelSU_group/3234/482579)并重新修补镜像并刷入后重启再开启selinux_hide功能解决
 
-> APatch/FolkPatch使用者[加载/嵌入此kpm](https://t.me/APatch_nightly/118)
+> APatch/FolkPatch使用者[加载/嵌入此kpm](https://github.com/Admirepowered/selinux_hook)
 
 > Magisk......尝试更换内核级管理器
 
@@ -66,11 +68,17 @@
 ## TEE环境不可信
 > 来自Tencent的[SoterService](https://github.com/Tencent/soter)
 > 作用: 微信的指纹支付等。
- 
+ > 通过比对Soter服务与Soter服务相关文件的存在一致性来判定是否存在Soterkey被屏蔽的情况。
+> 1. Soter服务不存在且Soter相关文件存在 -> Soter被屏蔽 （异常）
+> 2. Soter服务不存在且Soter相关文件不存在 -> 此设备原生不支持Soter服务 （正常）
+> 3. Soter服务正常且Soter相关文件存在 -> 此设备支持Soter （正常）
+> 4. Soter服务正常且Soter相关文件不存在 -> 不可能
 解决方法:
 
 > 等待模块更新 (不太可能实现SoterService的修复)
-> 使用susfs隐藏相关服务路径，并使用HMA-OSS对检测器隐藏Soter系统服务应用程序尝试解决
+> 使用susfs或PathMask隐藏相关服务路径，并使用HMA-OSS对检测器隐藏Soter系统服务应用程序尝试解决
+注意：PathMask并不专注于环境隐藏，请慎用
+原理：目前在技术上我们无法模拟Soter服务但可以隐藏Soter相关文件来伪造第2种情况。
 
 ## Tampered Attentionkey(X)
 > 携带20+类异常标签（多数是OEM特有标签）针对TEE处理异常标签反馈来对照预期值进行判断是否异常。
@@ -275,9 +283,12 @@ data 隔离？
 > 尝试更换""元模块"解决
 
 ## 挂载间隙
-> 检测挂载异常
-> 
+> 通过检查挂载组ID来判断是否存在隐藏root行为。
+> 在此判断方法中，当挂载组ID增长不连续时（例如1,2,3,6,7,8...）判定为存在隐藏root行为，反之，当挂载组ID增长连续（例如1,2,3,4,5,6,7...）则正常。
+> 解决办法：
+> Magisk系：使用Magisk Alpha可解决，原理未知。
 > 尝试更换"元模块"解决或者更新ROOT管理器
+在少数ROM中原生存在此现象，如果属于这种情况 请忽略此条目
 
 ## 2222
 > 检测挂载异常
@@ -330,9 +341,9 @@ data 隔离？
 ## 异常进程0000(pid）
 > 0000代表的是进程的pid
 > 
-> 你可以尝试使用shell指令以root执行“ps -ef | grep 数字id”来查找对应pid进程,通常是lspd进程
+> 你可以尝试使用shell指令以root执行“ps -ef | grep 数字id”来查找对应pid进程,通常是拥有root权限的守护进程（如lspd进程、Tricky-Store进程）
 > 
-> 也可以在系统设置中随便开一个软件分身尝试解决
+> 解决办法：此检测依赖安全漏洞，更新安全补丁到2026-01-01可显著降低检出率，但目前无法完全解决，等待Google在将来推出更新的安全补丁可完全解决此问题。
 
 > 会有误报现象
 

--- a/language/answer_zh.md
+++ b/language/answer_zh.md
@@ -25,7 +25,9 @@
 
 # 检测SELinux Policy时发现可疑问题 / 检测到ROOT权限
 > 检测方式参考 https://github.com/LSPosed/DirtySepolicy
+> 
 > 新加入的SELinux特性检测（应用程序 zygote 拥有访问 /sys/fs/selinux/access 的权限）
+> 
 > KSU使用者[更新KSU管理器](https://t.me/KernelSU_group/3234/482579)并重新修补镜像并刷入后重启再开启selinux_hide功能解决
 
 > APatch/FolkPatch使用者[加载/嵌入此kpm](https://github.com/Admirepowered/selinux_hook)
@@ -68,17 +70,21 @@
 ## TEE环境不可信
 > 来自Tencent的[SoterService](https://github.com/Tencent/soter)
 > 作用: 微信的指纹支付等。
+
  > 通过比对Soter服务与Soter服务相关文件的存在一致性来判定是否存在Soterkey被屏蔽的情况。
 > 1. Soter服务不存在且Soter相关文件存在 -> Soter被屏蔽 （异常）
 > 2. Soter服务不存在且Soter相关文件不存在 -> 此设备原生不支持Soter服务 （正常）
 > 3. Soter服务正常且Soter相关文件存在 -> 此设备支持Soter （正常）
 > 4. Soter服务正常且Soter相关文件不存在 -> 不可能
+
 解决方法:
 
 > 等待模块更新 (不太可能实现SoterService的修复)
 > 使用susfs或PathMask隐藏相关服务路径，并使用HMA-OSS对检测器隐藏Soter系统服务应用程序尝试解决
+
 注意：PathMask并不专注于环境隐藏，请慎用
-原理：目前在技术上我们无法模拟Soter服务但可以隐藏Soter相关文件来伪造第2种情况。
+
+原理：目前在技术上我们无法模拟Soter服务，但可以隐藏Soter相关文件来伪造第2种情况。
 
 ## Tampered Attentionkey(X)
 > 携带20+类异常标签（多数是OEM特有标签）针对TEE处理异常标签反馈来对照预期值进行判断是否异常。
@@ -171,7 +177,7 @@
 > 此检测项不稳定偶尔出现（通常使用KSU LKM模式的较多）
 
 ## Abnormal Environment
-> 检测到KSU/APatch/Magisk
+> 检测到KSU/APatch
 > 
 > 测信道检测,更新你的根管理器并重新修补
 
@@ -284,10 +290,13 @@ data 隔离？
 
 ## 挂载间隙
 > 通过检查挂载组ID来判断是否存在隐藏root行为。
+> 
 > 在此判断方法中，当挂载组ID增长不连续时（例如1,2,3,6,7,8...）判定为存在隐藏root行为，反之，当挂载组ID增长连续（例如1,2,3,4,5,6,7...）则正常。
+> 
 > 解决办法：
 > Magisk系：使用Magisk Alpha可解决，原理未知。
-> 尝试更换"元模块"解决或者更新ROOT管理器
+> Kernel系/APatch系：尝试更换"元模块"解决或者更新ROOT管理器
+
 在少数ROM中原生存在此现象，如果属于这种情况 请忽略此条目
 
 ## 2222


### PR DESCRIPTION
1. ”Miscellaneous Check(12)“与LSPosed无关且本身是检测Zygisk的实现。
2. 更新selinux_hook kpm的获取链接
3. 补充“TEE环境不可信”的解释
4. 补充“Abnormal Environment”的检测原理，且它不会被用来检测Magisk
5. 更正挂载间隙的原理解释，补充Magisk系的解决办法
6. 更正“异常进程0000(pid）”的解决办法