### PR TITLE
Restructure documentation with collapsible sections and Docsify search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,36 @@
-# Chunqiu Detector-Problem solution/春秋检测器问题解决方案
+# Chunqiu Detector-Problem solution / 春秋检测器问题解决方案
 
-> You can select your language below to view this document.
+> You can select your language below to view this document or visit our interactive online documentation platform.
 >
-> 您可以在下方选择语言查看此文档。
+> 您可以在下方选择语言查看此文档，或访问我们的在线交互文档平台（支持实时关键词搜索）。
 
-> The document will be modified (added/deleted/renamed) as the detector is updated
->
-> 随着检测器的更新，该文档将会被修改（添加/删除/重命名）。
-> 
-## language/语言
-> Select one of the following languages to view the solution file.
-> 
->请选择以下语言之一来查看解决方案文件。
-> 
-[中文](/language/answer_zh.md)|[English](/language/answer_en.md)
+## 🌐 交互式在线文档 / Interactive Web Site (GitHub Pages)
+👉 **[点击访问在线文档平台 (支持搜索框与信息展开/折叠)](https://mingzun09.github.io/Chunqiu-Detector-Problem-solution/)**
 
-> There are many embedded links in the document (highlighted in blue). You can click on them to be redirected to the relevant embedded address.
-> 
-> 文档中有很多嵌入式链接存在（蓝提醒色）你可以点击它，会跳转到嵌入的相关地址。
-> 
-## Feedback or participate in translation
-You can branch and modify the warehouse and then pull the request, and I will check and decide whether to merge.
+---
 
-## 反馈或参与翻译
+## 语言选择 / Language
+Select one of the following languages to view the solution file.
+请选择以下语言之一来查看解决方案文件。
 
-您可以创建分支并修改仓库，然后提交合并请求，我会检查并决定是否合并。
+[中文解决方案](/language/answer_zh.md) | [English Solutions](/language/answer_en.md)
+
+> 文档中包含大量嵌入式链接（蓝色突出显示），点击即可跳转至对应的项目/文件地址。
+> There are many embedded links in the document (highlighted in blue). You can click on them to be redirected to the relevant project/file address.
+
+---
+
+## 依赖与文件说明 / Files & Attachments
+仓库中包含了部分自动化修复脚本与 KPM 模块，位于 `/file/` 目录下：
+- `/file/found property.sh` - 修复 Found property 属性检测
+- `/file/tampered attestation key(26)pass.sh` - 修复证书 Patch 标签异常
+- `/file/shamiko_plus.sh` - 隐藏属性区空洞修改
+- `/file/bin/nohello-v1.8.2.9-83-b3e7d87-release.kpm` - APatch 隐藏 KPM 模块
+- `/file/doc/ksu_kp_sidechannel_zh.md` - KSU/APatch 侧信道检测原理说明
+
+---
+
+## 反馈与参与贡献 / Feedback & Contribute
+欢迎提交 Issues 或 Pull Requests 补充新的检测项及解决方案！
+
+You can fork and modify the repository, then pull requests. I will check and merge them.

--- a/_navbar.md
+++ b/_navbar.md
@@ -1,0 +1,4 @@
+* 语言 / Languages
+  * [中文 (Chinese)](/language/answer_zh.md)
+  * [English](/language/answer_en.md)
+* [GitHub 仓库](https://github.com/mingzun09/Chunqiu-Detector-Problem-solution)

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,0 +1,11 @@
+* **文档列表 / Documents**
+  * [中文解决方案](/language/answer_zh.md)
+  * [English Solutions](/language/answer_en.md)
+
+* **快速分类 / Categories**
+  * [说明与反馈](#说明与反馈)
+  * [Root 权限与 SELinux](#root-权限与-selinux-检测)
+  * [TEE 与密钥证明](#tee-与密钥证明检测)
+  * [挂载与命名空间](#挂载与命名空间检测)
+  * [环境、进程与文件](#环境进程与文件检测)
+  * [内核、属性与系统特征](#内核属性与系统特征检测)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <title>春秋检测器问题解决方案 - Chunqiu Detector Problem Solutions</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="description" content="春秋检测器问题解决方案 (Chunqiu Detector Problem Solution)">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+  <!-- Docsify Theme -->
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
+</head>
+<body>
+  <div id="app">加载中... / Loading...</div>
+  <script>
+    window.$docsify = {
+      name: '春秋检测器解决方案',
+      repo: 'https://github.com/mingzun09/Chunqiu-Detector-Problem-solution',
+      homepage: 'language/answer_zh.md',
+      auto2top: true,
+      loadNavbar: true,
+      loadSidebar: true,
+      subMaxLevel: 3,
+      alias: {
+        '/.*/_navbar.md': '/_navbar.md',
+        '/.*/_sidebar.md': '/_sidebar.md'
+      },
+      search: {
+        maxAge: 86400000,
+        paths: [
+          '/language/answer_zh.md',
+          '/language/answer_en.md'
+        ],
+        placeholder: {
+          '/': '搜索检测项或解决方案...',
+          '/language/': 'Search detection items or solutions...'
+        },
+        noData: {
+          '/': '未找到相关结果',
+          '/language/': 'No results found'
+        },
+        depth: 4
+      }
+    }
+  </script>
+  <!-- Docsify Core -->
+  <script src="//cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
+  <!-- Search Plugin -->
+  <script src="//cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.min.js"></script>
+  <!-- Copy code plugin -->
+  <script src="//cdn.jsdelivr.net/npm/docsify-copy-code/dist/docsify-copy-code.min.js"></script>
+</body>
+</html>

--- a/language/answer_en.md
+++ b/language/answer_en.md
@@ -3,471 +3,739 @@
 > Solutions with "?" at the end are uncertain.
 > Document Link: [github](https://github.com/mingzun09/Chunqiu-Detector-Problem-solution)
 
-# Detections you tried but can't pass
+## Table of Contents
+- [Help & Feedback](#help--feedback)
+- [Root Permissions & SELinux Detection](#root-permissions--selinux-detection)
+- [TEE & Key Attestation Detection](#tee--key-attestation-detection)
+- [Mounts & Namespaces Detection](#mounts--namespaces-detection)
+- [Environment, Processes & Files Detection](#environment-processes--files-detection)
+- [Kernel, Properties & System Characteristics Detection](#kernel-properties--system-characteristics-detection)
+
+---
+
+## Help & Feedback
+
+<details>
+<summary>Detections you tried but can't pass</summary>
+
 Open an issue with your module list and which Xposed modules you're using, etc. I'll reply/help when I have time.
+</details>
 
-# Miscellaneous Check(12)
-> Heuristic detection of Zygisk implementations (especially Zygisk-Next) via smaps scanning. However, the current implementation has issues that render the detection ineffective.
-> Please ignore this item until the detection method is fixed or removed.
+---
 
-# Looper fd Graph Anomaly
-> Under analysis for reproduction, to be supplemented...
+## Root Permissions & SELinux Detection
 
-# HMA Possibly Present
-> Suspected detection of old Scene_Hide-eBPF module behavior (cannot detect Scene app, but detects related services).
-> 
-> [Branch project / Pull update to rebuild module and flash / Download from Releases](https://github.com/Andrea-lyz/Scene-Port-Hider-by-eBPF)
+<details>
+<summary>Module Modifying Chunqiu Detected</summary>
 
-# Module Modifying Chunqiu Detected
 > Occurs after using the IsolPolicy module; resolve by disabling scope or uninstalling the module.
-
+>
 > It's not just modules — Magisk's hide features (e.g., SELinux modification hiding) can also trigger this. Try updating to the latest CI version of your root manager to resolve.
+</details>
 
-# Suspicious SELinux Policy Detected / ROOT Detected
+<details>
+<summary>Suspicious SELinux Policy Detected / ROOT Detected</summary>
+
 > Detection method reference: https://github.com/LSPosed/DirtySepolicy
 > 
 > New SELinux feature detection (app zygote has access to `/sys/fs/selinux/access`).
 > 
-> **KSU users:** [Update KSU Manager](https://t.me/KernelSU_group/3234/482579), re-patch image, flash, reboot, then enable selinux_hide feature.
+> **KSU users**: [Update KSU Manager](https://t.me/KernelSU_group/3234/482579), re-patch image, flash, reboot, then enable selinux_hide feature.
+>
+> **APatch/FolkPatch users**: [Load/embed this kpm](https://github.com/Admirepowered/selinux_hook)
+>
+> **selinux_hook module instructions**:
+> 1. Kernel version 4.19-6.12 devices MUST embed this module to take effect; loading mode will not enable any spoofing methods.
+>    *Note*: Due to machine instructions mismatch caused by compiler optimizations, 6.12 kernel devices should be careful when embedding this module as it has a high probability of causing a kernel panic. This will be fixed later.
+> 2. Kernel version 4.14 devices are recommended to embed the module. However, due to risks in simulating context_struct_compute_av, please backup original boot.img before embedding. Loading mode also works but uses keyword filtering fallback with worse results.
+> 3. Kernel version 4.9 devices are recommended to embed the module without context_struct_compute_av risks. Loading mode effect is identical to 4.14.
+>
+> **Magisk**: Try switching to a kernel-level manager. Magisk may merge saving clean policy blob feature in the future, which would allow Magisk to pass this detection.
+</details>
 
-> **APatch/FolkPatch users:** [Load/embed this kpm](https://github.com/Admirepowered/selinux_hook)
+<details>
+<summary>Found ksu/No-unlock Device</summary>
 
-> **Magisk:** ...try switching to a kernel-level manager.
+> KSU detected in jailbreak mode, current device using KSU jailbreak mode ROOT method, or KSU processes detected, etc.
+>
+> Jailbreak mode is not recommended, so no solution is provided here.
+</details>
 
-# fdinfo mnt Sampling Anomaly (c)
-> Likely detects USB debugging traces, low probability false positive. Try using the [ADB Trace Cleaner](https://github.com/YiJieqwq/ADB-Trace-Cleaner/releases) script to resolve.
+<details>
+<summary>SU binary detected</summary>
 
-# Memory Anomaly
-> Clear the detector app data first. If it persists, open an issue with your module list and which Xposed modules you're using, I'll look into it when I have time.
+> SU binary detected (ROOT detected).
+</details>
 
-# Futile hide 1
-> Rarely appears, cause unknown, no reliable solution yet.
+<details>
+<summary>SU list (Deleted)</summary>
 
-# Risky Applications
-> Means of detection unknown. Try using HMA-OSS to hide potentially risky apps from the detector.
+> Detected a ROOT permission exclusion list similar to KSU's.
+>
+> Unstable, appears occasionally (more common with KSU LKM mode).
+</details>
 
-# mountinfo
-> Mount views obtained via two different methods are inconsistent, suggesting potential concealment. Sometimes a service doesn't process in time and triggers this (early mountinfo snapshot vs. late comparison).
-> Xiaomi devices often show this when opening the detector under high system load after boot.
+<details>
+<summary>Abnormal Environment</summary>
 
-# Dirty Device(a)
-> Kernel interface detected? External sh detected?
-> Detects folders/files under `/storage/emulated/0/` with "sh" in their names.
-> Try restarting or reinstalling the system.
-> Delete any folders/files with "sh" in their names under `/storage/emulated/0/`.
+> Detects KSU/APatch (side-channel detection).
+>
+> Detection principle reference: [this document](/File/Doc/ksu_kp_sidechannel_zh.md)
+>
+> **Solution (KernelSU)**: Update your KernelSU Manager and re-patch (LKM work mode) or re-integrate (GKI and Non-GKI work mode).
+>
+> **Solution (APatch)**:
+> 1. Install [nohello kpm](/File/Bin/Nohello-v1.8.2.9-83-b3e7d87-release.kpm), and add the detector to the exclusion list. Nohello can check whether the app initiating the authentication request is in the exclusion list before kernelpatch evaluates the cmd value, and if so, deny the authentication.
+> 2. Future versions of APatch will introduce signature-based authentication, directly rejecting authentication requests from apps whose signatures do not match. This is not fully implemented yet and requires some waiting.
+>
+> **Solution (KPatch-Next)**: Update KPatch-Next driver to 0.13.5-2.
+>
+> Principle: Older KPatch-Next inherited KernelPatch authentication, making side-channel detection effective. The latest KPatch-Next authenticates via userland kpatch-android uid, bypassing side-channel detection.
+</details>
 
-## zygote test (1)
-> Enable ZygiskNext's linker function and anonymous memory function to try resolving.
-> Exclusion list strategy — Restore mount only.
-> Unstable detection, occasional occurrence.
+<details>
+<summary>KernelSU loop device</summary>
 
-## Inconsistent mount
-> Parses part of the mount from `/proc/self/exe/`, then checks if file system types are consistent.
-> Some devices have unfixed false positives (fixed in version 3.4).
+> KSU detected.
+>
+> Update your manager and re-patch.
+</details>
 
-## TEE Environment Untrusted
+<details>
+<summary>Suspicious Surroundings</summary>
+
+> APatch detected.
+>
+> Update APatch and load a KPM hiding module (e.g., Nohello.kpm).
+</details>
+
+<details>
+<summary>ROOT Process</summary>
+
+> Zygote environment detected?
+>
+> Read via audit log vulnerability (avc).
+>
+> Use SusFS features or the ZN-AuditPatch module.
+>
+> Fixed in Android security update 2025/09/01 (not entirely accurate, but that's the observation).
+</details>
+
+<details>
+<summary>Abnormal Process 0000 (pid)</summary>
+
+> 0000 represents the process PID.
+>
+> You can run `ps -ef | grep <pid>` as root to identify the process (often a root-privileged daemon, e.g., lspd, Tricky-Store process).
+>
+> **Solution**: This detection relies on a security vulnerability. Updating the security patch to 2026/01/01 can significantly reduce the detection rate, but it cannot be fully resolved at present. This security vulnerability will be completely fixed after Google officially releases Android 17.
+>
+> Security patch updates usually require system updates. If you do not wish to update your system, you can ignore this item.
+>
+> App cloning may temporarily bypass this check but does not resolve the underlying vulnerability.
+>
+> False positives may occur.
+</details>
+
+---
+
+## TEE & Key Attestation Detection
+
+<details>
+<summary>TEE Environment Untrusted</summary>
+
 > [SoterService from Tencent](https://github.com/Tencent/soter)
 > Purpose: WeChat fingerprint payments, etc.
-
+>
 > Detection method: Checks files to determine if Soter service programs exist and cross-validates with service point attribute status to determine if Soter key is blocked.
-> 1. Abnormal service point attributes + Soter program exists → Soter is blocked (Abnormal)
-> 2. Abnormal service point attributes + Soter program absent → This device natively does not support Soter (Normal)
-> 3. Normal service point attributes + Soter program exists → Device supports Soter (Normal)
-> 4. Normal service point attributes + Soter program absent → Impossible
+> 1. Abnormal service point attributes + Soter program exists -> Soter is blocked (Abnormal)
+> 2. Abnormal service point attributes + Soter program absent -> This device natively does not support Soter (Normal)
+> 3. Normal service point attributes + Soter program exists -> Device supports Soter (Normal)
+> 4. Normal service point attributes + Soter program absent -> Impossible
+>
+> **Solutions**:
+> - Wait for module updates (fixing SoterService is unlikely).
+> - Use SusFS or PathMask to hide related service paths, and use HMA-OSS to hide the Soter system service app from the detector to try resolving.
+>
+> *Note*: PathMask is not focused on environment hiding, use with caution.
+>
+> *Principle*: Currently we cannot technically simulate the Soter service, but we can hide Soter-related files to fake case #2.
+</details>
 
-Solutions:
+<details>
+<summary>Tampered Attentionkey(X)</summary>
 
-> Wait for module updates (fixing SoterService is unlikely).
-> Use SusFS or PathMask to hide related service paths, and use HMA-OSS to hide the Soter system service app from the detector to try resolving.
-
-Note: PathMask is not focused on environment hiding, use with caution.
-
-Principle: Currently we cannot technically simulate the Soter service, but we can hide Soter-related files to fake case #2.
-
-## Tampered Attentionkey(X)
 > Carries 20+ types of anomaly tags (mostly OEM-specific). Targets TEE's handling of anomaly tag feedback against expected values.
 >
 > For TEE detection — if present, wait for module updates or re-lock the bootloader.
 >
 > Even efisp's fake lock or custom bootloader "may" trigger this.
+>
+> - 15: HanAttest chain inconsistency (different source from TeeSim constant below, but in the same mask)
+> - 18: Vendor placeholder KeyMint tag still successfully issued a key (tee2 §1)
+> - 23: Leaf certificate KeyUsage contradicts KeyPurpose in extensions
+> - 24: Binder over-long alias / large transaction probe anomaly
+> - 25: Leaf certificate SigAlg does not match issuing key algorithm
+> - 26: Certificate patch tag inconsistent with system properties (related to security patches) ([execute this sh script](https://github.com/mingzun09/Chunqiu-Detector-Problem-solution/blob/main/File/Tampered%20Attestation%20Key(26)Pass.sh) to try resolving)
+> - 27: USER_ID appears in teeEnforced
+> - 29: APPLICATION_ID present without a challenge
+> - 30: Sensitive device identifier attestations not rejected (e.g., SERIAL)
+</details>
 
-> 15: HanAttest chain inconsistency (different source from TeeSim constant below, but in the same mask)
+<details>
+<summary>TrickyStore Hook/2</summary>
 
-> 18: Vendor placeholder KeyMint tag still successfully issued a key (tee2 §1)
-
-> 23: Leaf certificate KeyUsage contradicts KeyPurpose in extensions
-
-> 24: Binder over-long alias / large transaction probe anomaly
-
-> 25: Leaf certificate SigAlg does not match issuing key algorithm
-
-> 26: Certificate patch tag inconsistent with system properties (related to security patches) ([execute this sh script](https://github.com/mingzun09/Chunqiu-Detector-Problem-solution/blob/main/File/Tampered%20Attestation%20Key(26)Pass.sh) to try resolving)
-
-> 27: USER_ID appears in teeEnforced
-
-> 29: APPLICATION_ID present without a challenge
-
-> 30: Sensitive device identifier attestations not rejected (e.g., SERIAL)
-
-## Found property
-Execute [this sh script](https://github.com/mingzun09/Chunqiu-Detector-Problem-solution/blob/main/File/Found%20property.sh) to try resolving.
-
-## TrickyStore Hook/2
 > Timing side-channel (unstable). May disappear on re-open.
+>
 > Replace with [TEESimulator](https://github.com/JingMatrix/TEESimulator) module.
+</details>
 
-## Found TrickyStore/Similar Module
-> Attempt 1: Replace with [TEESimulator](https://github.com/JingMatrix/TEESimulator).
+<details>
+<summary>Found TrickyStore/Similar Module</summary>
 
-> Attempt 2: Delete `/data/adb/TrickyStore/security_patch.txt`.
+> **Attempt 1**: Replace with [TEESimulator](https://github.com/JingMatrix/TEESimulator).
+>
+> **Attempt 2**: Delete `/data/adb/tricky_store/security_patch.txt`.
+</details>
 
-## TEE Spoofing
+<details>
+<summary>TEE Spoofing</summary>
+
 > Use the TEESimulator(RS) module with certificate chain generation mode to resolve.
+</details>
 
-## Property Modified (Number represents how many properties were modified)
-> Principle: Checks for holes in the property area — if holes exist, properties have been modified.
+<details>
+<summary>TEE Damaged</summary>
 
-> To hide modified properties, add the [shamiko_Plus.sh](https://github.com/mingzun09/Chunqiu-Detector-Problem-solution/blob/main/File/shamiko_Plus.sh) file to `/data/adb/service.d/` and reboot to try resolving.
+> Try using Tricky Store or the [TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS) module.
+>
+> Use with [TS-Plugin](https://github.com/KOWX712/Tricky-Addon-Update-Target-List/releases/tag/v5.0-beta.1).
+>
+> Reboot after flashing, then open the module's webUI to configure.
+>
+> For TEE-damaged devices, use certificate chain generation mode.
+</details>
 
-## Environment Doubt 1 (Experimental Detection)
-> In HMA-OSS, if the "Input Method" option in preset settings is checked while hiding the detector in blacklist mode, this detection may appear?
+<details>
+<summary>Key Attestation Incomplete or Chain Inconsistent</summary>
 
-## Evil Service
-> Detection related to LSPosed, Shizuku, and some Xposed module modifications.
+> Use [TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS) and configure it to try resolving.
+</details>
 
-## Found ksu/No-unlock Device
-> KSU detected in jailbreak mode, current device using KSU jailbreak mode ROOT method, or KSU processes detected, etc.
+<details>
+<summary>AOSP Key</summary>
 
-> Jailbreak mode is not recommended, so no solution is provided here.
+> Replace `keybox.xml` in `/data/adb/tricky_store/`.
+>
+> You can also flash [TS-Plugin](https://github.com/KOWX712/Tricky-Addon-Update-Target-List/releases/tag/v5.0-beta.1). Reboot and open the module's webUI to configure keys.
+</details>
 
-## SU binary detected
-> SU binary detected (ROOT detected).
+<details>
+<summary>Boot Hash Mismatch</summary>
 
-## Miscellaneous Check (a)
-> dex2oat detected (Usually an LSP issue; replace/update the LSP module).
+> Boot image hash mismatch.
+>
+> Usually becomes `0000` after BL unlock. Use [Native detector](https://t.me/rootdetector/49) to get the correct hash, then use Tricky Store / [TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS) with [TS-Plugin](https://github.com/KOWX712/Tricky-Addon-Update-Target-List/releases/tag/v5.0-beta.1) to configure the hash.
+</details>
 
-## Mount loophole
+<details>
+<summary>Bootloader unlock</summary>
+
+> BL unlocked. Use [TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS) to hide.
+>
+> Configure `target.txt` in `/data/adb/tricky_store/` by adding the app package name (takes effect in real-time, no reboot needed).
+>
+> Also recommended: [TS-Plugin](https://github.com/KOWX712/Tricky-Addon-Update-Target-List/releases/tag/v5.0-beta.1) for visual package name configuration.
+</details>
+
+<details>
+<summary>Abnormal Boot Status</summary>
+
+> BL unlocked. Use [TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS) to hide.
+>
+> Configure `target.txt` in `/data/adb/tricky_store/` by adding the app package name (takes effect in real-time, no reboot needed).
+</details>
+
+<details>
+<summary>Key Tampering (128)</summary>
+
+> Tricky Store uses "Key Chain Generation Mode" by default on OnePlus Qualcomm devices.
+>
+> Try replacing with [TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS).
+</details>
+
+<details>
+<summary>Key Tampering (q)</summary>
+
+> Unknown.
+</details>
+
+<details>
+<summary>Key Tampering (b)</summary>
+
+> Unknown.
+</details>
+
+<details>
+<summary>Certificate Revoked (CRL)</summary>
+
+> Replace `keybox.xml` in `/data/adb/tricky_store/`.
+</details>
+
+<details>
+<summary>Key Tampering</summary>
+
+> [Use TEESimulator-RS?](https://github.com/Enginex0/TEESimulator-RS)
+</details>
+
+<details>
+<summary>TrustedCert Certificate Tampering</summary>
+
+> Unknown.
+</details>
+
+---
+
+## Mounts & Namespaces Detection
+
+<details>
+<summary>mountinfo</summary>
+
+> Mount views obtained via two different methods are inconsistent, suggesting potential concealment. Sometimes a service doesn't process in time and triggers this (early mountinfo snapshot vs. late comparison).
+> 
+> Xiaomi devices often show this when opening the detector under high system load after boot.
+</details>
+
+<details>
+<summary>zygote test (1)</summary>
+
+> Enable ZygiskNext's linker function and anonymous memory function to try resolving.
+> 
+> Exclusion list strategy — Restore mount only.
+> 
+> Unstable detection, occasional occurrence.
+</details>
+
+<details>
+<summary>Inconsistent mount</summary>
+
+> Parses part of the mount from `/proc/self/exe/`, then checks if file system types are consistent.
+> 
+> Some devices have unfixed false positives (fixed in version 3.4).
+</details>
+
+<details>
+<summary>Mount loophole</summary>
+
 > Magic Mount takes effect for system modification module mounts.
 > 
 > Mounting needs to be hidden by other modules (SusFS/ZygiskNext).
 > 
-> Use ZygiskNext's exclusion strategy > Restore mount only.
-> 
-> Configure the exclusion list / enable default module unmounting.
-> 
-> Hide it.
+> Use ZygiskNext's exclusion strategy > Restore mount only. Configure the exclusion list / enable default module unmounting to hide it.
+</details>
 
-## Magic Mount
+<details>
+<summary>Magic Mount</summary>
+
 > Magic Mount detected.
 > 
-> Try excluding certain system-modifying modules.
-> 
-> Use certain modules to hide this issue (e.g., ZygiskNext's exclusion strategy).
+> Try excluding certain system-modifying modules. Use certain modules to hide this issue (e.g., ZygiskNext's exclusion strategy).
+</details>
 
-## [Hook] Suspicious library injection
-(zygisk/riru/xposed)
-HOOK detected. Troubleshoot the cause yourself — too many possible factors.
+<details>
+<summary>Inconsistent mount / debug_ramdisk</summary>
 
-## SU list (Deleted)
-> Detected a ROOT permission exclusion list similar to KSU's.
-> 
-> Unstable, appears occasionally (more common with KSU LKM mode).
-
-## Abnormal Environment
-> Detects KSU/APatch (side-channel detection).
-> 
-> Detection principle reference: [this document](/File/Doc/ksu_kp_sidechannel_zh.md)
->
-> Solution (KernelSU): Update your KernelSU Manager and re-patch (LKM work mode) or re-integrate (GKI and Non-GKI work mode).
-> 
-> Solution (APatch):
-> 1. Install [nohello kpm](/File/Bin/Nohello-v1.8.2.9-83-b3e7d87-release.kpm), and add the detector to the exclusion list. Nohello can check whether the app initiating the authentication request is in the exclusion list before kernelpatch evaluates the cmd value, and if so, deny the authentication.
-> 2. Future versions of APatch will introduce signature-based authentication, directly rejecting authentication requests from apps whose signatures do not match. This is not fully implemented yet and requires some waiting.
-
-## Abnormal Environment (04)
-> New version changed to function call detection (unstable?).
-> 
-> Waiting for root manager/module updates?
-> 
-> APatch's exclusion modification enabled for the detector may cause this?
-
-## KernelSU loop device
-> KSU detected.
-> 
-> Update your manager and re-patch.
-
-## Suspicious Surroundings
-> APatch detected.
-> 
-> Update APatch and load a KPM hiding module (e.g., Nohello.kpm).
-
-## Device is an Emulator
-> Current device is an emulator device.
-
-## avb verification abnormal avb=2.0
-> Abnormal avb version.
-> 
-> Certain modules can cause this, such as device model changers. Troubleshoot yourself.
-
-## Found LSPHook Framework
-> LSPHook Framework detected.
-> 
-> Caused by certain Xposed module modifications. You can also uninstall and replace the LSP module.
-
-## Scene Port Occupied Detected
-> Check this [project](https://github.com/Andrea-lyz/Scene-Port-Hider-by-eBPF) to resolve.
-> 
-> Ignore this detection, or disable Scene's accessibility access.
->
-> Update Scene to v9.3.1+.
-
-## Zygisk detected
-> Zygisk detected — usually Magisk's built-in Zygisk (disable it) or other causes.
-> 
-> Update the [ZygiskNext module](http://github.com/Dr-TSNG/ZygiskNext).
-
-## Tampered kernel
-> Kernel information checksum abnormal (kernel version string, kernel build time).
-> 
-> Try using SusFS to hide it or restore the unmodified boot.img.
-
-## [hook] Resetprop modified
-> resetprop has been modified.
-> Unknown cause.
-
-## Suspicious Surroundings (a)
-> Path: `/data/local/tmp` folder's group is abnormal.
-
-Solution: Change group to shell.
-
-## Suspicious Surroundings (b)
-> Path: `/data/local/tmp` folder's inode value > 10000.
-
-Solutions: Factory reset the device / Use SusFS to spoof inode value < 1000 / Try using the [Inode-Hijacker](https://github.com/YiJieqwq/Inode-Hijacker/releases) script to resolve.
-If wired display projection (e.g. Scrcpy) becomes unavailable, use `su -c restorecon -RF /data/local/tmp` to resolve.
-
-## Suspicious Surroundings (c)
-> `/data/local/tmp` — permissions modified (default is 771).
-
-Solution: Reset permissions.
-
-## Futile hide
-> The following solutions may be outdated.
-> 
-> The timestamp of `/data/local/tmp` has been modified.
-> 
-> Format the system, or delete the `tmp` folder and reboot (this reverts to states a/b/c above), then use sukisu's Kstat config (requires kernel-integrated SusFS) to add `/data/local/tmp` with a modified inode value (e.g., 7365). Keep `tmp` permissions at 771 and owner as shell.
-
-## Miscellaneous Check (2)
-> Device tampering / model modification detected.
-> 
-> Caused by model-changing modules? Troubleshoot yourself.
-
-## Miscellaneous Check (3)
-> Device modification detection?
-> The following solution may be outdated.
-> Did you enable HMA's "Vold app data isolation"?
-
-## Inconsistent mount / debug_ramdisk
 > `umount /debug_ramdisk`
+</details>
 
-## Netlink socket anomaly
-> Currently unknown.
+<details>
+<summary>Futile hide 04</summary>
 
-## /data/local/tmp denied
-> Access to `/data/local/tmp` denied. Permission issue? Folder doesn't exist?
-
-## Spoofed Kernel
-> Ineffective use of SusFS to spoof the kernel.
-> 
-> Select `post-fs-data` during the kernel spoofing startup phase.
-
-## Futile hide 04
 > Principle: Mount namespace?
 > 
 > Mount abnormality detected.
 > 
 > Try replacing the "meta-module" to resolve.
+</details>
 
-## Mount Gap
+<details>
+<summary>Mount Gap</summary>
+
 > Determines whether root hiding behavior exists by checking mount group IDs.
-> 
-> In this method, when mount group IDs grow discontinuously (e.g., 1,2,3,6,7,8...), it is determined that root hiding behavior exists. Conversely, when mount group IDs grow continuously (e.g., 1,2,3,4,5,6,7...), it is normal.
 >
+> In this method, when mount group IDs grow discontinuously (e.g., 1,2,3,6,7,8...), it is determined that root hiding behavior exists. Conversely, when mount group IDs grow continuously (e.g., 1,2,3,4,5,6,7...), it is normal.
+> 
 > This phenomenon occurs when Magisk switches namespace. For KernelSU/APatch, it may also occur if certain modules with bind mount functionality are used.
-> 
-> Solutions:
-> Magisk: Use Magisk Alpha to resolve, principle unknown.
-> 
-> KernelSU/APatch: Try replacing the "meta-module" or updating the root manager.
+>
+> **Solutions**:
+> - **Magisk**: Use Magisk Alpha to resolve, principle unknown.
+> - **KernelSU/APatch**: Try replacing the "meta-module" or updating the root manager.
 >
 > If the problem persists, check system modules with bind mount functionality, and whether the system natively exhibits this phenomenon.
+> 
+> *Note*: A small number of ROMs natively exhibit this phenomenon. If this is the case, please ignore this item.
+</details>
 
-Note: A small number of ROMs natively exhibit this phenomenon. If this is the case, please ignore this item.
+<details>
+<summary>2222</summary>
 
-## 2222
 > Mount abnormality detected.
+</details>
 
-## Third-party Kernel
-> Kernel information matches a preset list.
-> 
-> Resolve by spoofing kernel information.
+---
 
-## Third-party ROM / Self-compiled Kernel
-> Third-party ROM flagged.
-> 
-> Kernel version suffix contains `-Dirty`.
-> 
-> Resolve by spoofing kernel information.
+## Environment, Processes & Files Detection
 
-## Third-party ROM (2)
-> Currently unknown.
+<details>
+<summary>Miscellaneous Check(12)</summary>
 
-## ROM detected
-> Third-party ROM detected.
+> Heuristic detection of Zygisk implementations (especially Zygisk-Next) via smaps scanning. However, the current implementation has issues that render the detection ineffective.
 > 
-> Some characteristics match known custom ROMs.
-> 
-> Try spoofing.
+> Please ignore this item until the detection method is fixed or removed.
+</details>
 
-## Suspicious Terminal Environment
+<details>
+<summary>Looper fd Graph Anomaly</summary>
+
+> Under analysis for reproduction, to be supplemented...
+</details>
+
+<details>
+<summary>HMA Possibly Present</summary>
+
+> Suspected detection of old Scene_Hide-eBPF module behavior (cannot detect Scene app, but detects related services).
+> 
+> [Branch project / Pull update to rebuild module and flash / Download from Releases](https://github.com/Andrea-lyz/Scene-Port-Hider-by-eBPF)
+</details>
+
+<details>
+<summary>fdinfo mnt Sampling Anomaly (c)</summary>
+
+> Likely detects USB debugging traces, low probability false positive. Try using the [ADB Trace Cleaner](https://github.com/YiJieqwq/ADB-Trace-Cleaner/releases) script to resolve.
+</details>
+
+<details>
+<summary>Memory Anomaly</summary>
+
+> Clear the detector app data first. If it persists, open an issue with your module list and which Xposed modules you're using, I'll look into it when I have time.
+</details>
+
+<details>
+<summary>Futile hide 1</summary>
+
+> Rarely appears, cause unknown, no reliable solution yet.
+</details>
+
+<details>
+<summary>Risky Applications</summary>
+
+> Means of detection unknown. Try using HMA-OSS to hide potentially risky apps from the detector.
+</details>
+
+<details>
+<summary>Dirty Device(a)</summary>
+
+> Kernel interface detected? External sh detected?
+> 
+> Detects folders/files under `/storage/emulated/0/` with "sh" in their names.
+>
+> Try restarting or reinstalling the system. Delete any folders/files with "sh" in their names under `/storage/emulated/0/`.
+</details>
+
+<details>
+<summary>Environment Doubt 1 (Experimental Detection)</summary>
+
+> In HMA-OSS, if the "Input Method" option in preset settings is checked while hiding the detector in blacklist mode, this detection may appear?
+</details>
+
+<details>
+<summary>Evil Service</summary>
+
+> Detection related to LSPosed, Shizuku, and some Xposed module modifications.
+</details>
+
+<details>
+<summary>Miscellaneous Check (a)</summary>
+
+> dex2oat detected (Usually an LSP issue; replace/update the LSP module).
+</details>
+
+<details>
+<summary>[Hook] Suspicious library injection</summary>
+
+> (zygisk/riru/xposed)
+>
+> HOOK detected. Troubleshoot the cause yourself — too many possible factors.
+</details>
+
+<details>
+<summary>Device is an Emulator</summary>
+
+> Current device is an emulator device.
+</details>
+
+<details>
+<summary>Found LSPHook Framework</summary>
+
+> LSPHook Framework detected.
+> 
+> Caused by certain Xposed module modifications. You can also uninstall and replace the LSP module.
+</details>
+
+<details>
+<summary>Scene Port Occupied Detected</summary>
+
+> Check this [project](https://github.com/Andrea-lyz/Scene-Port-Hider-by-eBPF) to resolve.
+> 
+> Ignore this detection, or disable Scene's accessibility access, or update Scene to v9.3.1+.
+</details>
+
+<details>
+<summary>Zygisk detected</summary>
+
+> Zygisk detected — usually Magisk's built-in Zygisk (disable it) or other causes.
+> 
+> Update the [ZygiskNext module](http://github.com/Dr-TSNG/ZygiskNext).
+</details>
+
+<details>
+<summary>Suspicious Surroundings (a)</summary>
+
+> Path: `/data/local/tmp` folder's group is abnormal.
+>
+> **Solution**: Change group to shell.
+</details>
+
+<details>
+<summary>Suspicious Surroundings (b)</summary>
+
+> Path: `/data/local/tmp` folder's inode value > 10000.
+>
+> **Solutions**: Factory reset the device / Use SusFS to spoof inode value < 1000 / Try using the [Inode-Hijacker](https://github.com/YiJieqwq/Inode-Hijacker/releases) script to resolve.
+>
+> If wired display projection (e.g. Scrcpy) becomes unavailable, use `su -c restorecon -RF /data/local/tmp` to resolve.
+</details>
+
+<details>
+<summary>Suspicious Surroundings (c)</summary>
+
+> `/data/local/tmp` — permissions modified (default is 771).
+>
+> **Solution**: Reset permissions.
+</details>
+
+<details>
+<summary>Futile hide</summary>
+
+> The following solutions may be outdated:
+> 
+> The timestamp of `/data/local/tmp` has been modified.
+> 
+> Format the system, or delete the `tmp` folder and reboot (this reverts to states a/b/c above), then use sukisu's Kstat config (requires kernel-integrated SusFS) to add `/data/local/tmp` with a modified inode value (e.g., 7365). Keep `tmp` permissions at 771 and owner as shell.
+</details>
+
+<details>
+<summary>/data/local/tmp denied</summary>
+
+> Access to `/data/local/tmp` denied. Permission issue? Folder doesn't exist?
+</details>
+
+<details>
+<summary>Suspicious Terminal Environment</summary>
+
 > Pty detected.
+</details>
 
-## Environment Fake
-> Old devices (Kernel 4.x) may have false positives?
-> This detection is triggered after flashing ZN-Audit Patch or similar modules.
-> 
-> Uninstall the ZN-Audit Patch module.
+<details>
+<summary>MT Manager (MT2 folder) / Abnormal Files</summary>
 
-## ROOT Process
-> Zygote environment detected?
-> 
-> Read via audit log vulnerability (avc).
-> 
-> Use SusFS features or the ZN-AuditPatch module.
-> 
-> Fixed in Android security update 2025/09/01 (not entirely accurate, but that's the observation).
-
-## Abnormal Process
-> Hidden process groups detected.
-> 
-> Try enabling an app clone (app twin) in system settings to resolve.
-
-## Abnormal Process 0000 (pid)
-> 0000 represents the process PID.
-> 
-> You can run `ps -ef | grep <pid>` as root to identify the process (often a root-privileged daemon, e.g., lspd, Tricky-Store process).
-> 
-> Solution: This detection relies on a security vulnerability. Updating the security patch to 2026-01-01 can significantly reduce the detection rate, but it cannot be fully resolved at present. This security vulnerability will be completely fixed after Google officially releases Android 17.
-> 
-> False positives may occur.
-
-## MT Manager (MT2 folder) / Abnormal Files
 > Abnormal files: Detects the `mt2` folder in root directory, `boot.img` files, and `.xml` abnormal files.
 > 
 > Change the MT2 path in MT Manager settings (custom path) and delete the old folder.
+</details>
 
-## Risk apps 'package name'
+<details>
+<summary>Risk apps 'package name'</summary>
+
 > Risk apps detected > package name.
 > 
-> Install the [Unicode Zero-Width Repair Module](https://t.me/real5ec1cff/268) to fix readability of `/storage/emulated/0/Android/data/`, then use HMA-OSS to hide risky apps.
+> Install the [Unicode Zero-Width Repair Module](https://github.com/5ec1cff/FuseFixer) to fix readability of `/storage/emulated/0/Android/data/`, then use HMA-OSS to hide risky apps.
+</details>
 
-## Thanox service detected
+<details>
+<summary>Thanox service detected</summary>
+
 > Thanox service detected.
 > 
 > Use the [hideThanox](https://t.me/Suxiaomingpd/125) Xposed module to hide it.
+</details>
 
-## Detection Failed
+<details>
+<summary>Abnormal Files</summary>
+
+> **Detection paths**: `/dev` and `/data/local/tmp`
+> 1. Rename or delete relevant directory files.
+> 2. Investigate and delete the following high-risk paths:
+>    ```text
+>    /data/local/stryker
+>    /data/system/appretention
+>    /data/local/tmp/luckys
+>    /data/local/tmp/input_devices
+>    /data/local/tmp/hyperceiler
+>    /data/local/tmp/simplehook
+>    /data/local/tmp/disabledallgoogleservices
+>    /data/local/mio
+>    /data/dna
+>    /data/local/tmp/cleaner_starter
+>    /data/local/tmp/byyang
+>    /data/local/tmp/mount_mask
+>    /data/local/tmp/mount_mark
+>    /data/local/tmp/scripttmp
+>    /data/local/luckys
+>    /data/local/tmp/horae_control.log
+>    /data/gpu_freq_table.conf
+>    /storage/emulated/0/download/advanced
+>    /storage/emulated/0/documents/advanced
+>    /data/system/noactive
+>    /data/system/freezer
+>    /storage/emulated/0/android/naki
+>    /data/swap_config.conf
+>    /data/local/tmp/resetprop
+>    ```
+</details>
+
+---
+
+## Kernel, Properties & System Characteristics Detection
+
+<details>
+<summary>Found property</summary>
+
+> Execute [this sh script](https://github.com/mingzun09/Chunqiu-Detector-Problem-solution/blob/main/File/Found%20property.sh) to try resolving.
+</details>
+
+<details>
+<summary>Property Modified (Number represents how many properties were modified)</summary>
+
+> Principle: Checks for holes in the property area — if holes exist, properties have been modified.
+> 
+> To hide modified properties, add the [shamiko_Plus.sh](https://github.com/mingzun09/Chunqiu-Detector-Problem-solution/blob/main/File/shamiko_Plus.sh) file to `/data/adb/service.d/` and reboot to try resolving.
+</details>
+
+<details>
+<summary>avb verification abnormal avb=2.0</summary>
+
+> Abnormal avb version.
+> 
+> Certain modules can cause this, such as device model changers. Troubleshoot yourself.
+</details>
+
+<details>
+<summary>Tampered kernel</summary>
+
+> Kernel information checksum abnormal (kernel version string, kernel build time).
+> 
+> Try using SusFS to hide it or restore the unmodified boot.img.
+</details>
+
+<details>
+<summary>[hook] Resetprop modified</summary>
+
+> resetprop has been modified.
+> 
+> Unknown cause.
+</details>
+
+<details>
+<summary>Miscellaneous Check (2)</summary>
+
+> Device tampering / model modification detected.
+> 
+> Caused by model-changing modules? Troubleshoot yourself.
+</details>
+
+<details>
+<summary>Miscellaneous Check (3)</summary>
+
+> Device modification detection?
+> 
+> The following solution may be outdated: Did you enable HMA's "Vold app data isolation"?
+</details>
+
+<details>
+<summary>Netlink socket anomaly</summary>
+
+> Currently unknown.
+</details>
+
+<details>
+<summary>Spoofed Kernel</summary>
+
+> Ineffective use of SusFS to spoof the kernel.
+>
+> Select `post-fs-data` during the kernel spoofing startup phase.
+</details>
+
+<details>
+<summary>Third-party Kernel</summary>
+
+> Kernel information matches a preset list.
+> 
+> Resolve by spoofing kernel information.
+</details>
+
+<details>
+<summary>Third-party ROM / Self-compiled Kernel</summary>
+
+> Third-party ROM flagged.
+> 
+> Kernel version suffix contains `-Dirty`.
+>
+> Resolve by spoofing kernel information.
+</details>
+
+<details>
+<summary>Third-party ROM (2)</summary>
+
+> Currently unknown.
+</details>
+
+<details>
+<summary>ROM detected</summary>
+
+> Third-party ROM detected.
+>
+> Some characteristics match known custom ROMs.
+>
+> Try spoofing.
+</details>
+
+<details>
+<summary>Environment Fake</summary>
+
+> Old devices (Kernel 4.x) may have false positives?
+>
+> This detection is triggered after flashing ZN-Audit Patch or similar modules.
+>
+> Uninstall the ZN-Audit Patch module.
+</details>
+
+<details>
+<summary>Detection Failed</summary>
+
 > 2333333
+</details>
 
-## TEE Damaged
-> Try using Tricky Store or the [TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS) module.
-Use with [TS-Plugin](https://github.com/KOWX712/Tricky-Addon-Update-Target-List/releases/tag/v5.0-beta.1).
-Reboot after flashing, then open the module's webUI to configure.
-> For TEE-damaged devices, use certificate chain generation mode.
+<details>
+<summary>Something wrong</summary>
 
-## Key Attestation Incomplete or Chain Inconsistent
-> Use [TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS) and configure it to try resolving.
-
-## AOSP Key
-> Replace `keybox.xml` in `/data/adb/Tricky Store/`.
-You can also flash [TS-Plugin](https://github.com/KOWX712/Tricky-Addon-Update-Target-List/releases/tag/v5.0-beta.1).
-Reboot and open the module's webUI to configure keys.
-
-## Boot Hash Mismatch
-> Boot image hash mismatch.
-> 
-> Usually becomes `0000` after BL unlock. Use [Native detector](https://t.me/rootdetector/49) to get the correct hash, then use Tricky Store / [TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS) with [TS-Plugin](https://github.com/KOWX712/Tricky-Addon-Update-Target-List/releases/tag/v5.0-beta.1) to configure the hash.
-
-## Bootloader unlock
-> BL unlocked. Use [TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS) to hide.
-Configure `target.txt` in `/data/adb/tricky_store/` by adding the app package name (takes effect in real-time, no reboot needed).
-Also recommended: [TS-Plugin](https://github.com/KOWX712/Tricky-Addon-Update-Target-List/releases/tag/v5.0-beta.1) for visual package name configuration.
-> 
-
-## Abnormal Boot Status
-> BL unlocked. Use [TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS) to hide.
-Configure `target.txt` in `/data/adb/tricky_store/` by adding the app package name (takes effect in real-time, no reboot needed).
-
-## Key Tampering (128)
-> Tricky Store uses "Key Chain Generation Mode" by default on OnePlus Qualcomm devices.
-
-> Try replacing with [TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS).
-
-## Key Tampering (q)
 > Unknown.
+</details>
 
-## Key Tampering (b)
-> Unknown.
+<details>
+<summary>Miscellaneous Check (4/5/6/7/8/9)</summary>
 
-## Certificate Revoked (CRL)
-> Replace `keybox.xml` in `/data/adb/tricky_store/`.
-
-## Key Tampering
-> [Use TEESimulator-RS?](https://github.com/Enginex0/TEESimulator-RS)
-
-## TrustedCert Certificate Tampering
-> Unknown.
-
-## Something wrong
-> Unknown.
-
-## Miscellaneous Check (4/5/6/7/8/9)
 > Some detections related to emulator/virtual machine characteristics, device modification behavior, or third-party/ported ROMs.
 > 
 > False positives on international devices like Poco/Samsung (to be fixed).
-
-## Abnormal Files
-- Detection paths: `/dev` and `/data/local/tmp`
-  1. Rename or delete relevant directory files.
-  2. Investigate and delete the following high-risk paths:
-     ```
-     /data/local/stryker
-     /data/system/AppRetention
-     /data/local/tmp/luckys
-     /data/local/tmp/input_devices
-     /data/local/tmp/HyperCeiler
-     /data/local/tmp/simpleHook
-     /data/local/tmp/DisabledAllGoogleServices
-     /data/local/MIO
-     /data/DNA
-     /data/local/tmp/cleaner_starter
-     /data/local/tmp/byyang
-     /data/local/tmp/mount_mask
-     /data/local/tmp/mount_mark
-     /data/local/tmp/scriptTMP
-     /data/local/luckys
-     /data/local/tmp/horae_control.log
-     /data/gpu_freq_table.conf
-     /storage/emulated/0/Download/advanced
-     /storage/emulated/0/Documents/advanced
-     /data/system/NoActive
-     /data/system/Freezer
-     /storage/emulated/0/Android/naki
-     /data/swap_config.conf
-     /data/local/tmp/resetprop
-     ```
-
-## Magic Mount
-> Use ZygiskNext's exclusion strategy > Restore mount only.
-> Configure the exclusion list / enable default module unmounting to hide it.
+</details>

--- a/language/answer_zh.md
+++ b/language/answer_zh.md
@@ -1,483 +1,739 @@
 # 春秋检测项解决方案（跟进最新版本）中文版
 > 整理：mingzun09(SuXiaoMing) | 仅供参考，具体结果因设备/环境而异。
->解决方案尾巴带“?”符号的都为不确定
+> 解决方案尾巴带“?”符号的都为不确定
 > 文档链接：[github](https://github.com/mingzun09/Chunqiu-Detector-Problem-solution)
 
-# 自行尝试但仍然无法通过的检测
-请开Issues并提供 你的模块列表信息+使用了哪些xp模块等详细修改 我有时间会回复/帮助。
+## 目录
+- [说明与反馈](#说明与反馈)
+- [Root 权限与 SELinux 检测](#root-权限与-selinux-检测)
+- [TEE 与密钥证明检测](#tee-与密钥证明检测)
+- [挂载与命名空间检测](#挂载与命名空间检测)
+- [环境、进程与文件检测](#环境进程与文件检测)
+- [内核、属性与系统特征检测](#内核属性与系统特征检测)
 
-# Miscellaneous Check(12)
-> 通过扫描smaps启发式探测Zygisk实现（特别是Zygisk-Next），但目前的实现方式存在问题，导致检测失效。
-> 在检测方法被修复或移除前请忽略此条目
+---
 
-# Looper fd图异常
-> 暂时未知
+## 说明与反馈
 
-# HMA或许存在
-> 疑似检测旧版使用Scene_Hide-eBPF模块行为（检测不到scene应用程序存在，但检测到相关服务）
+<details>
+<summary>自行尝试但仍然无法通过的检测</summary>
+
+请开 Issues 并提供你的模块列表信息 + 使用了哪些 Xposed 模块等详细修改，我有时间会回复/帮助。
+</details>
+
+---
+
+## Root 权限与 SELinux 检测
+
+<details>
+<summary>存在模块修改春秋</summary>
+
+> 使用 IsolPolicy 模块后出现，关闭作用域或者卸载模块解决。
 > 
-> [分支项目/拉取更新重新构建模块并刷入/从Releases中下载](https://github.com/Andrea-lyz/Scene-Port-Hider-by-eBPF)
+> 并不是只有模块，比如说类似于面具的隐藏也算（比如 SELinux 修改隐藏）请尝试跟进相关 root 管理器最新 CI 来解决此问题。
+</details>
 
-# 存在模块修改春秋
-> 使用IsolPolicy模块后出现，关闭作用域或者卸载模块解决
+<details>
+<summary>检测SELinux Policy时发现可疑问题 / 检测到ROOT权限</summary>
 
-> 并不是只有模块，比如说类似于面具的隐藏也算（比如SELinux修改隐藏）请尝试跟进相关root管理器最新CI来解决此问题
-
-# 检测SELinux Policy时发现可疑问题 / 检测到ROOT权限
-> 检测方式参考 https://github.com/LSPosed/DirtySepolicy
-> 
-> 新加入的SELinux特性检测（应用程序 zygote 拥有访问 /sys/fs/selinux/access 的权限）
-> 
-> KSU使用者[更新KSU管理器](https://t.me/KernelSU_group/3234/482579)并重新修补镜像并刷入后重启再开启selinux_hide功能解决
-
-> APatch/FolkPatch使用者[使用此kpm](https://github.com/Admirepowered/selinux_hook)
-
-> selinux_hook模块使用说明
-> 1. 内核版本4.19-6.12的设备，必须嵌入此模块才能生效，如果使用加载模式，则不会启用任何伪装方法。
-> 注意：由于编译优化导致的机器指令与预期不符，6.12内核设备请慎重嵌入此模块，会有很大概率导致kernelpanic，此问题后续将会被解决。
-> 2. 内核版本4.14的设备，建议嵌入模块，但由于模拟context_struct_compute_av存在风险，在嵌入模块前请备份原boot.img，以便在出现kernelpanic后可救砖；加载模式同样可生效，但会使用基于关键词过滤的备选方法，效果相对较差，如果设备的policy中包含了模块没有收录的且能被证明异常的关键词，则会发生泄露。
-> 3. 内核版本4.9的设备，建议嵌入模块，且无模拟context_struct_compute_av的风险，加载模式效果同4.14。
-
-> Magisk......尝试更换内核级管理器
-> 
-> 在将来Magisk可能会合并保存Clean policy blob功能，如果合并此功能，Magisk将有机会通过此检测。
-
-# fdinfo mnt 采样异常（c）
-> 大概率为检测到USB调试痕迹，小概率误报。可使用脚本[调试痕迹消除](https://github.com/YiJieqwq/ADB-Trace-Cleaner/releases)尝试解决
-
-# 内存异常
-> 清除检测器数据后若还存在，那么请开Issues并提供你的模块列表信息以及使用了哪些xp模块，我有时间会研究的
-
-# Futile hide 1
-> 很少人出现，暂时未知原因，暂时没有可靠的解决方案
-
-# 风险应用
-> 暂时未知的手段，自行尝试使用HMA-OSS对检测器隐藏某些可能是风险的应用程序。
-
-# mountinfo
-> 通过两种手段获取出来的挂载视图不一样。可能存在隐瞒的问题,有时某服务处理不及时就会报（极早 mountinfo 快照 vs 后期对照）
-> 小米设备通常在开机后系统高占用时，打开检测器会出现，此检测项
-
-# Drity Device(a)
-> 检测到内核接口？外挂sh?
->检测到/storage/emulated/0/目录有文件夹/文件
->名称有sh？
->尝试重启手机或刷机
->删除在/storage/emulated/0/带有sh字样的文件
->夹/文件
-
-## zygote test (1)
-> 打开ZygiskNext的链接器功能与匿名内存功能尝试解决。
-> 排除列表策略-仅还原挂载。
-> 不稳定检测，侧信道
-
-## Inconsistent mount
-> /proc/self/exe/解析出其中部分的挂载，然后再去看文件系统类型是否一致。（挂载的类型不同）
-> 存在部分设备暂未修复的误报现象（3.4版本中已修复）
-
-## TEE环境不可信
-> 来自Tencent的[SoterService](https://github.com/Tencent/soter)
-> 作用: 微信的指纹支付等。
-
- > 通过检查文件来判断是否存在Soter服务程序以及判断其服务点属性状态来交叉验证是否存在Soterkey被屏蔽的情况。
-> 1. 服务点属性状态异常 + Soter服务程序存在 -> Soter被屏蔽 （异常）
-> 2. 服务点属性状态异常 + Soter服务程序不存在 -> 此设备原生不支持Soter服务 （正常）
-> 3. 服务点属性状态正常 + Soter服务程序存在 -> 此设备支持Soter （正常）
-> 4. 服务点属性状态正常 + Soter服务程序不存在 -> 不可能
-
-解决方法:
-
-> 等待模块更新（不太可能实现SoterService的修复）
-> 使用SusFS或PathMask隐藏相关服务路径，并使用HMA-OSS对检测器隐藏Soter系统服务应用程序尝试解决
-
-注意：PathMask并不专注于环境隐藏，请慎用
-
-原理：目前在技术上我们无法模拟Soter服务，但可以隐藏Soter相关文件来伪造第2种情况。
-
-## Tampered Attentionkey(X)
-> 携带20+类异常标签（多数是OEM特有标签）针对TEE处理异常标签反馈来对照预期值进行判断是否异常。
+> 检测方式参考：https://github.com/LSPosed/DirtySepolicy
 >
-> 针对TEE的检测，若有，“请等待相关模块更新修复”，或者回锁。
+> 新加入的 SELinux 特性检测（应用程序 zygote 拥有访问 `/sys/fs/selinux/access` 的权限）
 >
-> 即使是efisp 的假锁或者自定义引导程序也“可能”会报
+> **KSU 使用者**：[更新KSU管理器](https://t.me/KernelSU_group/3234/482579)并重新修补镜像并刷入后重启，再开启 selinux_hide 功能解决。
+>
+> **APatch/FolkPatch 使用者**：[使用此kpm](https://github.com/Admirepowered/selinux_hook)
+>
+> **selinux_hook 模块使用说明**：
+> 1. 内核版本 4.19-6.12 的设备，必须嵌入此模块才能生效，如果使用加载模式，则不会启用任何伪装方法。
+>    *注意*：由于编译优化导致的机器指令与预期不符，6.12 内核设备请慎重嵌入此模块，会有很大概率导致 kernelpanic，此问题后续将会被解决。
+> 2. 内核版本 4.14 的设备，建议嵌入模块，但由于模拟 context_struct_compute_av 存在风险，在嵌入模块前请备份原 boot.img，以便在出现 kernelpanic 后可救砖；加载模式同样可生效，但会使用基于关键词过滤的备选方法，效果相对较差，如果设备的 policy 中包含了模块没有收录的且能被证明异常的关键词，则会发生泄露。
+> 3. 内核版本 4.9 的设备，建议嵌入模块，且无模拟 context_struct_compute_av 的风险，加载模式效果同 4.14。
+>
+> **Magisk**：尝试更换内核级管理器。在将来 Magisk 可能会合并保存 Clean policy blob 功能，如果合并此功能，Magisk 将有机会通过此检测。
+</details>
 
-> 15: HanAttest 链不一致（与下面 TeeSim 常量不同源，但同在 mask 里）
+<details>
+<summary>Found ksu/免解设备</summary>
 
-> 18: 厂商占位 KeyMint tag 仍成功输出密钥（tee2 §1）
-
-> 23: 叶证书 KeyUsage 与扩展内 KeyPurpose 矛盾
-
-> 24: Binder 超长 alias / 大事务探针异常
-
-> 25: 叶证书 SigAlg 与签发钥算法不符
-
-> 26: 证书 patch 标签与系统属性不一致（与安全补丁有关）（[执行此sh](https://github.com/mingzun09/Chunqiu-Detector-Problem-solution/blob/main/File/Tampered%20Attestation%20Key(26)Pass.sh)尝试解决）
-
-> 27: USER_ID 出现在 teeEnforced
-
-> 29: 无 challenge 却有 APPLICATION_ID（上表）
-
-> 30: 敏感设备标识类 attest 未被拒绝（如 SERIAL）
-
-## Found property
-执行[此sh](https://github.com/mingzun09/Chunqiu-Detector-Problem-solution/blob/main/File/Found%20property.sh)尝试解决
-
-## TrickyStore Hook/2
-> 测信道（不稳定）重新打开或许消失
-> 更换模块[TEESimulator](https://github.com/JingMatrix/TEESimulator)
-
-## 发现TrickyStore/类似模块
-> 尝试1
-更换模块比如[TEESimulator](https://github.com/JingMatrix/TEESimulator)
-
->尝试2
-把/data/adb/TrickyStore/security_patch.txt文件删除
-
-## TEE伪造
-> 使用TEESimulator(RS)模块解决，使用证书链生成模式。
-
-## Property Modified（数字代表几处属性修改）
-> 原理是查属性区空洞，如果说有存在空洞的话，说明存在属性修改。
-
-> 隐藏被修改的属性可将shamiko模块中的[shamiko_Plus.sh](https://github.com/mingzun09/Chunqiu-Detector-Problem-solution/blob/main/File/shamiko_Plus.sh)文件添加并移动到/data/adb/service.d/目录下，确认该脚本有执行权限后重启，尝试解决。
-
-## 环境存疑1（实验性检测）
-> 在HMA-OSS中对检测器开启黑名单模式隐藏后，若勾选了设置预设中的“输入法”选项后，此检测项就会出现？
-
-## Evil Service
-> 关于lsp shuziku 还有一些xp模块的修改检测
-
-## Found ksu/免解设备
-> 发现ksu处于越狱模式，当前设备使用ksu越狱模式的ROOT方式或者发现ksu进程等其他因素。
-
-> 不推荐使用越狱模式，所以不提供解决方案
-
-## SU binary detected
-> 检测到SU二进制文件（检测到ROOT）
-
-## Miscellaneous Check（a）
-> 检测到dex2oat（通常是LSP的问题，更换/更新LSP模块）
-
-## Mount loophole
-> Magic Mount对系统修改模块挂载生效
+> 发现 ksu 处于越狱模式，当前设备使用 ksu 越狱模式的 ROOT 方式或者发现 ksu 进程等其他因素。
 > 
-> 但挂载需要其他模块来隐藏（可选择SusFS/ZygiskNext）
-> 
-> 使用ZygiskNext的排除策略>仅还原挂载
-> 
-> 并配置排除列表/开启默认卸载模块
-> 
-> 对其隐藏
+> 不推荐使用越狱模式，所以不提供解决方案。
+</details>
 
-## Magic Mount
-> 检测到Magic Mount
-> 
-> 请尝试排除某些针对系统修改的模块
-> 
-> 使用某些模块隐藏这个问题（比如ZygiskNext中的排除策略）
+<details>
+<summary>SU binary detected</summary>
 
-## [Hook] Suspicious library injection
-(zygisk/riru/xposed)
-检测到HOOK，自行排查原因，因素过多
-## SU list（已被删除）
-> 检测到类似ksu的ROOT权限排除列表
-> 
-> 此检测项不稳定偶尔出现（通常使用KSU LKM模式的较多）
+> 检测到 SU 二进制文件（检测到 ROOT）
+</details>
 
-## Abnormal Environment
-> 检测到KSU/APatch（侧信道检测）
+<details>
+<summary>SU list（已被删除）</summary>
+
+> 检测到类似 ksu 的 ROOT 权限排除列表
 > 
+> 此检测项不稳定偶尔出现（通常使用 KSU LKM 模式的较多）
+</details>
+
+<details>
+<summary>Abnormal Environment</summary>
+
+> 检测到 KSU/APatch（侧信道检测）
+>
 > 检测原理请参考[此文档](/File/Doc/ksu_kp_sidechannel_zh.md)
 >
-> 解决办法（KernelSU系）：更新你的KernelSU管理器并重新修补（LKM工作模式）或重新集成（GKI和Non-GKI工作模式）
-> 
-> 解决办法（APatch系）：
-> 1. 嵌入/加载[nohello kpm](/File/Bin/Nohello-v1.8.2.9-83-b3e7d87-release.kpm)，并将检测器加入到排除列表，nohello可以在kernelpatach判断cmd值之前判断发起鉴权请求的应用是否在排除列表内，如果是，则禁止鉴权。
-> 2. 未来版本的APatch会引入基于签名的鉴权方法，对于不符合签名却发起了鉴权的应用直接拒绝鉴权请求。目前没有完全实现，需要再等一段时间。
-> 
-> 解决办法（KPatch-Next）：更新KPatch-Next驱动到0.13.5-2
-> 
-> 原理：旧版KPatch-Next完全继承了KernelPatch的鉴权方式，所以在APatch上可行的测信道检测方法在旧版KPatch-Next上也同样可行；但最新版KPatch-Next以判断用户态kpatch-android组件的uid实现鉴权，不再会被测信道检测。
+> **解决办法（KernelSU 系）**：更新你的 KernelSU 管理器并重新修补（LKM 工作模式）或重新集成（GKI 和 Non-GKI 工作模式）。
+>
+> **解决办法（APatch 系）**：
+> 1. 嵌入/加载[nohello kpm](/File/Bin/Nohello-v1.8.2.9-83-b3e7d87-release.kpm)，并将检测器加入到排除列表，nohello 可以在 kernelpatch 判断 cmd 值之前判断发起鉴权请求的应用是否在排除列表内，如果是，则禁止鉴权。
+> 2. 未来版本的 APatch 会引入基于签名的鉴权方法，对于不符合签名却发起了鉴权的应用直接拒绝鉴权请求。目前没有完全实现，需要再等一段时间。
+>
+> **解决办法（KPatch-Next）**：更新 KPatch-Next 驱动到 0.13.5-2。
+>
+> 原理：旧版 KPatch-Next 完全继承了 KernelPatch 的鉴权方式，所以在 APatch 上可行的侧信道检测方法在旧版 KPatch-Next 上也同样可行；但最新版 KPatch-Next 以判断用户态 kpatch-android 组件的 uid 实现鉴权，不再会被侧信道检测。
+</details>
 
+<details>
+<summary>KernelSU loop device</summary>
 
-## KernelSU loop device
-> 检测到KSU
+> 检测到 KSU
 > 
 > 更新你的管理器并重新修补
+</details>
 
-## Suspicious Surroundings
-> 检测到APatch
-> 
-> 更新APatch并加载KPM隐藏模块解决（比如Nohello.kpm）
+<details>
+<summary>Suspicious Surroundings</summary>
 
-## 设备为模拟器
-> 当前是模拟器设备
-
-## avb校验异常 avb=2.0
-
-> avb版本异常
-> 
-> 某些模块会造成此问题，比如改机型模块，自行排查模块尝试解决。
-
-## Found LSPHook Framework
-> 检测到LSPhook Framework
-> 
-> 某些xp模块修改导致,也可卸载更换LSP模块
-
-## 检测到Scene端口占用
-> 请查看此[项目](https://github.com/Andrea-lyz/Scene-Port-Hider-by-eBPF)并尝试解决
-> 
-> 无视此检测项，或者关闭scene的无障碍权限
+> 检测到 APatch
 >
-> 将scene更新到9.3.1以上
+> 更新 APatch 并加载 KPM 隐藏模块解决（比如 Nohello.kpm）
+</details>
 
-## Zygisk detected
-> 检测到Zygisk,通常是magisk自带的zygisk导致（关闭解决）或者其他原因
-> 
-> 更新[ZygiskNext模块](http://github.com/Dr-TSNG/ZygiskNext)
+<details>
+<summary>ROOT进程</summary>
 
-## Tampered kernel
-> 内核信息校验异常（内核字符版本，内核构建时间）
-> 
-> 尝试使用SusFS隐藏或者还原未修改的boot.img
+> 检测 Zygote 环境?
+>
+> 通过审计日志漏洞读取 (avc)
+>
+> 可使用 SusFS 的功能或者使用 ZN-AuditPatch 模块
+>
+> Android 安全更新 2025/09/01 已修复（不准确但结果是这样的）
+</details>
 
-## [hook]Resetprop modified
-> resetprop被修改
+<details>
+<summary>异常进程0000（pid）</summary>
+
+> 0000 代表的是进程的 pid
+>
+> 你可以尝试使用 shell 指令以 root 执行 `ps -ef | grep 数字id` 来查找对应 pid 进程，通常是拥有 root 权限的守护进程（如 lspd 进程、Tricky-Store 进程）
+>
+> **解决办法**：此检测依赖安全漏洞，更新安全补丁到 2026/01/01 可显著降低检出率，但目前无法完全解决，此安全漏洞将在 Google 正式发布 Android 17 后完全修复。
+>
+> 安全补丁更新往往伴随系统更新，如果因为不想更新系统而无法更新安全补丁，可以忽略此条目。
+>
+> 双开应用有时可以使此检测方案失效，但不会实质上解决此安全漏洞，所以双开应用不应被视为可行的方法。
+>
+> 会有误报现象
+</details>
+
+---
+
+## TEE 与密钥证明检测
+
+<details>
+<summary>TEE环境不可信</summary>
+
+> 来自 Tencent 的 [SoterService](https://github.com/Tencent/soter)
+> 作用: 微信的指纹支付等。
+>
+> 通过检查文件来判断是否存在 Soter 服务程序以及判断其服务点属性状态来交叉验证是否存在 Soter key 被屏蔽的情况。
+> 1. 服务点属性状态异常 + Soter 服务程序存在 -> Soter 被屏蔽（异常）
+> 2. 服务点属性状态异常 + Soter 服务程序不存在 -> 此设备原生不支持 Soter 服务（正常）
+> 3. 服务点属性状态正常 + Soter 服务程序存在 -> 此设备支持 Soter（正常）
+> 4. 服务点属性状态正常 + Soter 服务程序不存在 -> 不可能
+>
+> **解决方法**：
+> - 等待模块更新（不太可能实现 SoterService 的修复）
+> - 使用 SusFS 或 PathMask 隐藏相关服务路径，并使用 HMA-OSS 对检测器隐藏 Soter 系统服务应用程序尝试解决
+>
+> *注意*：PathMask 并不专注于环境隐藏，请慎用。
+>
+> *原理*：目前在技术上我们无法模拟 Soter 服务，但可以隐藏 Soter 相关文件来伪造第 2 种情况。
+</details>
+
+<details>
+<summary>Tampered Attentionkey(X)</summary>
+
+> 携带 20+ 类异常标签（多数是 OEM 特有标签）针对 TEE 处理异常标签反馈来对照预期值进行判断是否异常。
+>
+> 针对 TEE 的检测，若有，“请等待相关模块更新修复”，或者回锁。
+>
+> 即使是 efisp 的假锁或者自定义引导程序也“可能”会报。
+>
+> - 15: HanAttest 链不一致（与下面 TeeSim 常量不同源，但同在 mask 里）
+> - 18: 厂商占位 KeyMint tag 仍成功输出密钥（tee2 §1）
+> - 23: 叶证书 KeyUsage 与扩展内 KeyPurpose 矛盾
+> - 24: Binder 超长 alias / 大事务探针异常
+> - 25: 叶证书 SigAlg 与签发钥算法不符
+> - 26: 证书 patch 标签与系统属性不一致（与安全补丁有关）（[执行此sh](https://github.com/mingzun09/Chunqiu-Detector-Problem-solution/blob/main/File/Tampered%20Attestation%20Key(26)Pass.sh)尝试解决）
+> - 27: USER_ID 出现在 teeEnforced
+> - 29: 无 challenge 却有 APPLICATION_ID（上表）
+> - 30: 敏感设备标识类 attest 未被拒绝（如 SERIAL）
+</details>
+
+<details>
+<summary>TrickyStore Hook/2</summary>
+
+> 侧信道（不稳定）重新打开或许消失
+>
+> 更换模块[TEESimulator](https://github.com/JingMatrix/TEESimulator)
+</details>
+
+<details>
+<summary>发现TrickyStore/类似模块</summary>
+
+> **尝试1**：更换模块比如 [TEESimulator](https://github.com/JingMatrix/TEESimulator)
+>
+> **尝试2**：把 `/data/adb/tricky_store/security_patch.txt` 文件删除
+</details>
+
+<details>
+<summary>TEE伪造</summary>
+
+> 使用 TEESimulator(RS) 模块解决，使用证书链生成模式。
+</details>
+
+<details>
+<summary>TEE 损坏</summary>
+
+> 尝试使用 Tricky Store 或者 [TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS) 模块解决，搭配 [TS插件使用](https://github.com/KOWX712/Tricky-Addon-Update-Target-List/releases/tag/v5.0-beta.1)。
+>
+> 刷入后请重启，开机后打开模块的 webUI 进行配置。
+>
+> TEE 损坏的设备请使用生成证书链模式。
+</details>
+
+<details>
+<summary>密钥证明未完成或链不一致</summary>
+
+> 使用 [TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS) 并配置后尝试解决
+</details>
+
+<details>
+<summary>AOSP密钥</summary>
+
+> 更换 `/data/adb/tricky_store/` 目录下的 `keybox.xml` 文件。
+>
+> 也可选择刷入 [TS插件](https://github.com/KOWX712/Tricky-Addon-Update-Target-List/releases/tag/v5.0-beta.1)，重启后打开模块的 webUI 界面进行密钥配置。
+</details>
+
+<details>
+<summary>Boot Hash不匹配</summary>
+
+> boot 镜像的 Hash 不匹配。
+>
+> 通常 BL 解锁后 hash 会变成 0000，使用 [Native detector](https://t.me/rootdetector/49) 获取正确的 hash 后使用 Tricky Store/[TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS) 模块并使用 [TS插件](https://github.com/KOWX712/Tricky-Addon-Update-Target-List/releases/tag/v5.0-beta.1) 配置 hash 解决。
+</details>
+
+<details>
+<summary>Bootloader unlock</summary>
+
+> BL 已解锁，使用 [TEESimulator-RS模块隐藏](https://github.com/Enginex0/TEESimulator-RS)。
+>
+> 需要配置 `/data/adb/tricky_store/` 目录下的 `target.txt` 文件，在其中添加软件包名（实时生效无需重启）。
+>
+> 也推荐使用 [TS插件](https://github.com/KOWX712/Tricky-Addon-Update-Target-List/releases/tag/v5.0-beta.1) 进行软件包名的可视化配置。
+</details>
+
+<details>
+<summary>启动状态异常</summary>
+
+> BL 已解锁，使用 [TEESimulator-RS模块隐藏](https://github.com/Enginex0/TEESimulator-RS)。
+>
+> 需要配置 `/data/adb/tricky_store/` 目录下的 `target.txt` 文件，在其中添加软件包名（实时生效无需重启）。
+</details>
+
+<details>
+<summary>密钥篡改(128)</summary>
+
+> Tricky Store 在一加高通设备上默认使用"密钥链生成模式"
+>
+> 尝试更换 [TEESimulator-RS模块](https://github.com/Enginex0/TEESimulator-RS)
+</details>
+
+<details>
+<summary>密钥篡改（q）</summary>
+
 > 未知
+</details>
 
-## Suspicious Surroundings (a)
-> /data/local/tmp 文件夹所有组异常
+<details>
+<summary>密钥篡改（b）</summary>
 
-解决方案: 所有组改为shell
+> 未知
+</details>
 
-## Suspicious Surroundings（b）
-> 路径/data/local/tmp 文件夹的inode值高于10000
+<details>
+<summary>证书已被吊销(CRL)</summary>
 
-解决方案: 将设备恢复出厂设置 / 使用SusFS对路径伪装inode值小于1000 / 尝试使用[Inode-Hijacker](https://github.com/YiJieqwq/Inode-Hijacker/releases)脚本解决
-如遇到有线投屏（如Scrcpy）不可用，使用 su -c restorecon -RF /data/local/tmp 解决问题
+> 更换 `/data/adb/tricky_store/` 目录下的 `keybox.xml` 文件
+</details>
 
-## Suspicious Surroundings（c）
-> /data/local/tmp 的权限被修改（默认771）
+<details>
+<summary>密钥篡改</summary>
 
-解决方案: 重新设置权限
+> [使用TEESimulator-RS模块?](https://github.com/Enginex0/TEESimulator-RS)
+</details>
 
-## Futile hide
-> 以下方案可能过时
+<details>
+<summary>TrustedCert 证书篡改</summary>
+
+> 未知
+</details>
+
+---
+
+## 挂载与命名空间检测
+
+<details>
+<summary>mountinfo</summary>
+
+> 通过两种手段获取出来的挂载视图不一样。可能存在隐瞒的问题,有时某服务处理不及时就会报（极早 mountinfo 快照 vs 后期对照）
 > 
-> /data/local/tmp文件夹tmp的时间被修改
+> 小米设备通常在开机后系统高占用时，打开检测器会出现此检测项。
+</details>
+
+<details>
+<summary>zygote test (1)</summary>
+
+> 打开 ZygiskNext 的链接器功能与匿名内存功能尝试解决。
 > 
-> 格式化系统或者把tmp文件夹删除重启后变上方abc再使用sukisu中的Kstat配置（需要内核集成SusFS）添加/data/local/tmp目录只修改ino值比如7365（tmp目录权限保持771，所有者为shell。
-
-## Miscellaneous Check(2)
-> 检测设备篡改/机型篡改
+> 排除列表策略-仅还原挂载。
 > 
-> 改机型模块导致?自行排查
+> 不稳定检测，侧信道。
+</details>
 
-## Miscellaneous Check(3)
-> 改机检测？
-> 以下方案可能过时
-> 开启过“隐藏应用列表(HMA)”的 Vold app
-data 隔离？
+<details>
+<summary>Inconsistent mount</summary>
 
-## 不一致的挂载/debug_ramdisk
-> umount /debug_ramdisk
-
-## Netlink socket anomaly
-> 暂时未知
-
-## /data/local/tmp denied
-> 目录/data/local/tmp拒绝访问,文件夹权限设置问题?文件夹不存在?
-
-## 伪装内核
-> 无效的使用SusFS伪装内核
+> `/proc/self/exe/` 解析出其中部分的挂载，然后再去看文件系统类型是否一致。（挂载的类型不同）
 > 
-> 伪装内核启动阶段选择post-fs-data
+> 存在部分设备暂未修复的误报现象（3.4版本中已修复）。
+</details>
 
-## Futile hide 04
+<details>
+<summary>Mount loophole</summary>
+
+> Magic Mount 对系统修改模块挂载生效
+> 
+> 但挂载需要其他模块来隐藏（可选择 SusFS/ZygiskNext）
+> 
+> 使用 ZygiskNext 的排除策略 > 仅还原挂载，并配置排除列表 / 开启默认卸载模块对其实施隐藏。
+</details>
+
+<details>
+<summary>Magic Mount</summary>
+
+> 检测到 Magic Mount
+> 
+> 请尝试排除某些针对系统修改的模块，使用某些模块隐藏这个问题（比如 ZygiskNext 中的排除策略）。
+</details>
+
+<details>
+<summary>不一致的挂载/debug_ramdisk</summary>
+
+> `umount /debug_ramdisk`
+</details>
+
+<details>
+<summary>Futile hide 04</summary>
+
 > 原理-挂载命名空间?
 > 
 > 检测挂载异常
-> 
-> 尝试更换""元模块"解决
+>
+> 尝试更换"元模块"解决
+</details>
 
-## 挂载间隙
-> 通过检查挂载组ID来判断是否存在隐藏root行为。
-> 
-> 在此判断方法中，当挂载组ID增长不连续时（例如1,2,3,6,7,8...）判定为存在隐藏root行为，反之，当挂载组ID增长连续（例如1,2,3,4,5,6,7...）则正常。
+<details>
+<summary>挂载间隙</summary>
+
+> 通过检查挂载组 ID 来判断是否存在隐藏 root 行为。
 >
-> 当Magisk系切换namespace时将出现此现象，而对于KernelSU系/APatch系，如果使用了某些具有绑定挂载功能的模块也可能出现此现象。
+> 在此判断方法中，当挂载组 ID 增长不连续时（例如 1,2,3,6,7,8...）判定为存在隐藏 root 行为；反之，当挂载组 ID 增长连续（例如 1,2,3,4,5,6,7...）则正常。
 > 
-> 解决办法：
-> Magisk系：使用Magisk Alpha可解决，原理未知。
+> 当 Magisk 系切换 namespace 时将出现此现象，而对于 KernelSU 系/APatch 系，如果使用了某些具有绑定挂载功能的模块也可能出现此现象。
 > 
-> Kernel系/APatch系：尝试更换"元模块"解决或者更新ROOT管理器
->
+> **解决办法**：
+> - **Magisk 系**：使用 Magisk Alpha 可解决，原理未知。
+> - **Kernel 系/APatch 系**：尝试更换"元模块"解决或者更新 ROOT 管理器。
+> 
 > 如果问题仍存在，请检查具有绑定挂载功能的系统模块，以及系统是否原生存在此现象。
+>
+> *注意*：在少数 ROM 中原生存在此现象，如果属于这种情况请忽略此条目。
+</details>
 
-注意：在少数ROM中原生存在此现象，如果属于这种情况 请忽略此条目
+<details>
+<summary>2222</summary>
 
-## 2222
 > 检测挂载异常
+</details>
 
-## 第三方内核
-> 内核信息符合预设信息名单
-> 
-> 伪装内核信息解决
+---
 
-## 第三方rom/自编译内核
-> 第三方ROM标记
-> 
-> 内核版本号后缀带有-Dirty
-> 
-> 伪装内核信息解决
+## 环境、进程与文件检测
 
-## 第三方ROM（2）
+<details>
+<summary>Miscellaneous Check(12)</summary>
+
+> 通过扫描 smaps 启发式探测 Zygisk 实现（特别是 Zygisk-Next），但目前的实现方式存在问题，导致检测失效。
+> 
+> 在检测方法被修复或移除前请忽略此条目。
+</details>
+
+<details>
+<summary>Looper fd图异常</summary>
+
 > 暂时未知
+</details>
 
-## ROM detected
-> 检测到第三方ROM
+<details>
+<summary>HMA或许存在</summary>
+
+> 疑似检测旧版使用 Scene_Hide-eBPF 模块行为（检测不到 scene 应用程序存在，但检测到相关服务）
 > 
-> 部分三方rom特征符合
+> [分支项目/拉取更新重新构建模块并刷入/从Releases中下载](https://github.com/Andrea-lyz/Scene-Port-Hider-by-eBPF)
+</details>
+
+<details>
+<summary>fdinfo mnt 采样异常（c）</summary>
+
+> 大概率为检测到 USB 调试痕迹，小概率误报。可使用脚本[调试痕迹消除](https://github.com/YiJieqwq/ADB-Trace-Cleaner/releases)尝试解决。
+</details>
+
+<details>
+<summary>内存异常</summary>
+
+> 清除检测器数据后若还存在，那么请开 Issues 并提供你的模块列表信息以及使用了哪些 xp 模块，我有时间会研究的。
+</details>
+
+<details>
+<summary>Futile hide 1</summary>
+
+> 很少人出现，暂时未知原因，暂时没有可靠的解决方案。
+</details>
+
+<details>
+<summary>风险应用</summary>
+
+> 暂时未知的手段，自行尝试使用 HMA-OSS 对检测器隐藏某些可能是风险的应用程序。
+</details>
+
+<details>
+<summary>Drity Device(a)</summary>
+
+> 检测到内核接口？外挂 sh?
 > 
-> 可自行尝试伪装
+> 检测到 `/storage/emulated/0/` 目录有文件夹/文件名称有 sh？
+> 
+> 尝试重启手机或刷机，删除在 `/storage/emulated/0/` 带有 sh 字样的文件夹/文件。
+</details>
 
-## 终端环境存疑
-> 检测Pty
+<details>
+<summary>环境存疑1（实验性检测）</summary>
 
-## 环境伪造
+> 在 HMA-OSS 中对检测器开启黑名单模式隐藏后，若勾选了设置预设中的“输入法”选项后，此检测项就会出现？
+</details>
+
+<details>
+<summary>Evil Service</summary>
+
+> 关于 lsp, shizuku 还有一些 xp 模块的修改检测。
+</details>
+
+<details>
+<summary>Miscellaneous Check（a）</summary>
+
+> 检测到 dex2oat（通常是 LSP 的问题，更换/更新 LSP 模块）。
+</details>
+
+<details>
+<summary>[Hook] Suspicious library injection</summary>
+
+> (zygisk/riru/xposed)
+> 
+> 检测到 HOOK，自行排查原因，因素过多。
+</details>
+
+<details>
+<summary>设备为模拟器</summary>
+
+> 当前是模拟器设备。
+</details>
+
+<details>
+<summary>Found LSPHook Framework</summary>
+
+> 检测到 LSPHook Framework
+> 
+> 某些 xp 模块修改导致，也可卸载更换 LSP 模块。
+</details>
+
+<details>
+<summary>检测到Scene端口占用</summary>
+
+> 请查看此[项目](https://github.com/Andrea-lyz/Scene-Port-Hider-by-eBPF)并尝试解决。
+> 
+> 无视此检测项，或者关闭 scene 的无障碍权限，或将 scene 更新到 9.3.1 以上。
+</details>
+
+<details>
+<summary>Zygisk detected</summary>
+
+> 检测到 Zygisk，通常是 magisk 自带的 zygisk 导致（关闭解决）或者其他原因。
+> 
+> 更新[ZygiskNext模块](http://github.com/Dr-TSNG/ZygiskNext)。
+</details>
+
+<details>
+<summary>Suspicious Surroundings (a)</summary>
+
+> `/data/local/tmp` 文件夹所有组异常。
+>
+> **解决方案**：所有组改为 shell。
+</details>
+
+<details>
+<summary>Suspicious Surroundings（b）</summary>
+
+> 路径 `/data/local/tmp` 文件夹的 inode 值高于 10000。
+> 
+> **解决方案**：将设备恢复出厂设置 / 使用 SusFS 对路径伪装 inode 值小于 1000 / 尝试使用 [Inode-Hijacker](https://github.com/YiJieqwq/Inode-Hijacker/releases) 脚本解决。
+> 
+> 如遇到有线投屏（如 Scrcpy）不可用，使用 `su -c restorecon -RF /data/local/tmp` 解决问题。
+</details>
+
+<details>
+<summary>Suspicious Surroundings（c）</summary>
+
+> `/data/local/tmp` 的权限被修改（默认 771）。
+> 
+> **解决方案**：重新设置权限。
+</details>
+
+<details>
+<summary>Futile hide</summary>
+
+> 以下方案可能过时：
+> 
+> `/data/local/tmp` 文件夹 tmp 的时间被修改。
+> 
+> 格式化系统或者把 tmp 文件夹删除重启后变上方 abc，再使用 sukisu 中的 Kstat 配置（需要内核集成 SusFS）添加 `/data/local/tmp` 目录只修改 ino 值比如 7365（tmp 目录权限保持 771，所有者为 shell）。
+</details>
+
+<details>
+<summary>/data/local/tmp denied</summary>
+
+> 目录 `/data/local/tmp` 拒绝访问，文件夹权限设置问题? 文件夹不存在?
+</details>
+
+<details>
+<summary>终端环境存疑</summary>
+
+> 检测 Pty。
+</details>
+
+<details>
+<summary>MT管理器（MT2文件夹）/异常文件</summary>
+
+> 异常文件：检测到根目录下的“mt2”文件夹与 boot.img / “.xml”异常文件。
+> 
+> “mt2”可在 MT 管理器设置中对 MT2 路径自定义修改解决（记得删除旧文件夹）。
+</details>
+
+<details>
+<summary>Risk apps‘软件包名’</summary>
+
+> 通过 Unicode 零宽字符漏洞检查 `/storage/emulated/0/Android/data/` 中的风险应用包名。
+> 
+> 安装 [Unicode零宽修复模块](https://github.com/5ec1cff/FuseFixer) 对 `/storage/emulated/0/Android/data/` 目录修复可被读取问题，并搭配 HMA-OSS 对风险应用隐藏。
+</details>
+
+<details>
+<summary>Thanox service detected</summary>
+
+> 检测到 Thanox 服务。
+> 
+> 可以使用这个 xp 模块来隐藏：[hideThanox](https://t.me/Suxiaomingpd/125)。
+</details>
+
+<details>
+<summary>异常文件</summary>
+
+> **检测路径**：`/dev` 和 `/data/local/tmp`
+> 1. 重命名/删除相关目录文件。
+> 2. 排查并删除以下高危路径：
+>    ```text
+>    /data/local/stryker
+>    /data/system/appretention
+>    /data/local/tmp/luckys
+>    /data/local/tmp/input_devices
+>    /data/local/tmp/hyperceiler
+>    /data/local/tmp/simplehook
+>    /data/local/tmp/disabledallgoogleservices
+>    /data/local/mio
+>    /data/dna
+>    /data/local/tmp/cleaner_starter
+>    /data/local/tmp/byyang
+>    /data/local/tmp/mount_mask
+>    /data/local/tmp/mount_mark
+>    /data/local/tmp/scripttmp
+>    /data/local/luckys
+>    /data/local/tmp/horae_control.log
+>    /data/gpu_freq_table.conf
+>    /storage/emulated/0/download/advanced
+>    /storage/emulated/0/documents/advanced
+>    /data/system/noactive
+>    /data/system/freezer
+>    /storage/emulated/0/android/naki
+>    /data/swap_config.conf
+>    /data/local/tmp/resetprop
+>    ```
+</details>
+
+---
+
+## 内核、属性与系统特征检测
+
+<details>
+<summary>Found property</summary>
+
+> 执行[此sh](https://github.com/mingzun09/Chunqiu-Detector-Problem-solution/blob/main/File/Found%20property.sh)尝试解决。
+</details>
+
+<details>
+<summary>Property Modified（数字代表几处属性修改）</summary>
+
+> 原理是查属性区空洞，如果说有存在空洞的话，说明存在属性修改。
+> 
+> 隐藏被修改的属性可将 shamiko 模块中的 [shamiko_Plus.sh](https://github.com/mingzun09/Chunqiu-Detector-Problem-solution/blob/main/File/shamiko_Plus.sh) 文件添加并移动到 `/data/adb/service.d/` 目录下，确认该脚本有执行权限后重启，尝试解决。
+</details>
+
+<details>
+<summary>avb校验异常 avb=2.0</summary>
+
+> avb 版本异常。
+> 
+> 某些模块会造成此问题，比如改机型模块，自行排查模块尝试解决。
+</details>
+
+<details>
+<summary>Tampered kernel</summary>
+
+> 内核信息校验异常（内核字符版本，内核构建时间）。
+> 
+> 尝试使用 SusFS 隐藏或者还原未修改的 boot.img。
+</details>
+
+<details>
+<summary>[hook]Resetprop modified</summary>
+
+> resetprop 被修改。
+> 
+> 未知。
+</details>
+
+<details>
+<summary>Miscellaneous Check(2)</summary>
+
+> 检测设备篡改/机型篡改。
+> 
+> 改机型模块导致? 自行排查。
+</details>
+
+<details>
+<summary>Miscellaneous Check(3)</summary>
+
+> 改机检测？
+>
+> 以下方案可能过时：开启过“隐藏应用列表(HMA)”的 Vold appdata 隔离？
+</details>
+
+<details>
+<summary>Netlink socket anomaly</summary>
+
+> 暂时未知
+</details>
+
+<details>
+<summary>伪装内核</summary>
+
+> 无效的使用 SusFS 伪装内核。
+> 
+> 伪装内核启动阶段选择 post-fs-data。
+</details>
+
+<details>
+<summary>第三方内核</summary>
+
+> 内核信息符合预设信息名单。
+> 
+> 伪装内核信息解决。
+</details>
+
+<details>
+<summary>第三方rom/自编译内核</summary>
+
+> 第三方 ROM 标记。
+>
+> 内核版本号后缀带有 `-Dirty`。
+>
+> 伪装内核信息解决。
+</details>
+
+<details>
+<summary>第三方ROM（2）</summary>
+
+> 暂时未知
+</details>
+
+<details>
+<summary>ROM detected</summary>
+
+> 检测到第三方 ROM。
+>
+> 部分三方 rom 特征符合。
+>
+> 可自行尝试伪装。
+</details>
+
+<details>
+<summary>环境伪造</summary>
+
 > 旧设备（4系内核）可能或误报？
-> 此检测项在刷入ZN-Audit Patch模块或类似行为后会触发。
 > 
-> 卸载ZN-Audit Patch模块
+> 此检测项在刷入 ZN-Audit Patch 模块或类似行为后会触发。
+>
+> 卸载 ZN-Audit Patch 模块。
+</details>
 
-## ROOT进程
-> 检测Zygote环境?
-> 
-> 通过审计日志漏洞读取(avc)
-> 
-> 可使用SusFS的功能或者使用ZN-AuditPatch模块
-> 
-> Android安全更新25/09/01已修复（不准确但结果是这样的）
+<details>
+<summary>检测失败</summary>
 
-## 异常进程0000（pid）
-> 0000代表的是进程的pid
-> 
-> 你可以尝试使用shell指令以root执行“ps -ef | grep 数字id”来查找对应pid进程,通常是拥有root权限的守护进程（如lspd进程、Tricky-Store进程）
-> 
-> 解决办法：此检测依赖安全漏洞，更新安全补丁到2026-01-01可显著降低检出率，但目前无法完全解决，此安全漏洞将在Google正式发布Android 17后完全修复。
-> 
-> 安全补丁更新往往伴随系统更新，如果因为不想更新系统而无法更新安全补丁，可以忽略此条目。
-> 
-> 双开应用有时可以使此检测方案失效，但不会实质上解决此安全漏洞，所以双开应用不应被视为可行的方法。
-
-> 会有误报现象
-
-## MT管理器（MT2文件夹）/异常文件
-> 异常文件：检测到根目录下的“mt2”文件夹与boot.img/“.xml”异常文件。
-> 
-> “mt2”可在MT管理器设置中对MT2路径自定义修改解决（记得删除旧文件夹）
-
-## Risk apps‘软件包名’
-> 通过Unicode零宽字符漏洞检查/storage/emulated/0/Android/data/中的风险应用包名
-> 
-> 安装[Unicode零宽修复模块](https://github.com/5ec1cff/FuseFixer)对/storage/emulated/0/Android/data/目录修复可被读取问题并搭配HMA-OSS对风险应用隐藏。
-
-## Thanox service detected
-> 检测到Thanox服务
-> 
-> 可以使用这个xp模块来隐藏[hideThanox](https://t.me/Suxiaomingpd/125)
-
-## 检测失败
 > 2333333
+</details>
 
-## TEE 损坏
-> 尝试使用Tricky Store或者[TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS)模块解决
-搭配[TS插件使用](https://github.com/KOWX712/Tricky-Addon-Update-Target-List/releases/tag/v5.0-beta.1)
-刷入后请重启，开机后打开模块的webUI进行配置。
-> TEE损坏的设备请使用生成证书链模式
+<details>
+<summary>Something wrong</summary>
 
-## 密钥证明未完成或链不一致
-> 使用[TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS)并配置后尝试解决
-
-## AOSP密钥
-> 更换/data/adb/Tricky Store/目录下的'keybox.xml'文件
-也可选择刷入[TS插件](https://github.com/KOWX712/Tricky-Addon-Update-Target-List/releases/tag/v5.0-beta.1)
-重启后打开模块的webui界面进行密钥配置
-
-## Boot Hash不匹配
-> boot镜像的Hash不匹配
-> 
-> 通常BL解锁后hash会变成0000,使用[Native detector](https://t.me/rootdetector/49)获取正确的hash后使用Tricky Store/[TEESimulator-RS](https://github.com/Enginex0/TEESimulator-RS)模块并使用[TS插件](https://github.com/KOWX712/Tricky-Addon-Update-Target-List/releases/tag/v5.0-beta.1)配置hash解决
-
-## Bootloader unlock
-> BL已解锁,使用[TEESimulator-RS模块隐藏](https://github.com/Enginex0/TEESimulator-RS)
-需要配置/data/adb/tricky_store/目录下的target.txt文件，在其中添加软件包名（实时生效无需重启）
-也推荐使用[TS插件](https://github.com/KOWX712/Tricky-Addon-Update-Target-List/releases/tag/v5.0-beta.1)进行软件包名的可视化配置
-> 
-## 启动状态异常
-> BL已解锁,使用[TEESimulator-RS模块隐藏](https://github.com/Enginex0/TEESimulator-RS)
-需要配置/data/adb/tricky_store/目录下的target.txt文件，在其中添加软件包名（实时生效无需重启）
-
-## 密钥篡改(128)
-> Tricky Store在一加高通设备上默认使用"密钥链生成模式"
-
-> 尝试更换[TEESimulator-RS模块](https://github.com/Enginex0/TEESimulator-RS)
-
-## 密钥篡改（q）
 > 未知
+</details>
 
-## 密钥篡改（b）
-> 未知
+<details>
+<summary>Miscellaneous Check(4/5/6/7/8/9)</summary>
 
-## 证书已被吊销(CRL)
-> 更换/data/adb/tricky_store/目录下的keybox.xml文件
-
-## 密钥篡改
-> [使用TEESimulator-RS模块?](https://github.com/Enginex0/TEESimulator-RS)
-
-## TrustedCert 证书篡改
-> 未知
-
-## Something wrong
-> 未知
-
-## Miscellaneous Check(4/5/6/7/8/9)
-> 一些有关模拟器虚拟机/模拟器的检测/改机行为检测/三方&移植ROM
-> 
-> 在国外设备Poco/三星误报情况（待修复）
-
-## 异常文件
-- 检测路径：/dev和/data/local/tmp
-  1. 重命名/删除相关目录文件
-  2. 排查并删除以下高危路径：
-     ```
-     /data/local/stryker
-     /data/system/AppRetention
-     /data/local/tmp/luckys
-     /data/local/tmp/input_devices
-     /data/local/tmp/HyperCeiler
-     /data/local/tmp/simpleHook
-     /data/local/tmp/DisabledAllGoogleServices
-     /data/local/MIO
-     /data/DNA
-     /data/local/tmp/cleaner_starter
-     /data/local/tmp/byyang
-     /data/local/tmp/mount_mask
-     /data/local/tmp/mount_mark
-     /data/local/tmp/scriptTMP
-     /data/local/luckys
-     /data/local/tmp/horae_control.log
-     /data/gpu_freq_table.conf
-     /storage/emulated/0/Download/advanced
-     /storage/emulated/0/Documents/advanced
-     /data/system/NoActive
-     /data/system/Freezer
-     /storage/emulated/0/Android/naki
-     /data/swap_config.conf
-     /data/local/tmp/resetprop
-     ```
-
-## Magic Mount
-> 使用ZygiskNext的排除策略>仅还原挂载
-> 并配置排除列表/开启默认卸载模块
-> 对其隐藏
+> 一些有关模拟器虚拟机/模拟器的检测/改机行为检测/三方&移植 ROM。
+>
+> 在国外设备 Poco/三星误报情况（待修复）。
+</details>


### PR DESCRIPTION
Restructures the documentation to group items by logical categories with collapsible `<details>` tags for better readability and sets up Docsify for GitHub Pages to enable interactive full-text keyword search and multi-language navigation.

---
*PR created automatically by Jules for task [3564746749174962227](https://jules.google.com/task/3564746749174962227) started by @mingzun09*